### PR TITLE
Add Matdata YASGUI fork to OKG catalog

### DIFF
--- a/data/software.json
+++ b/data/software.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-03T10:08:43Z",
+  "generatedAt": "2026-08-03T13:05:58Z",
   "items": [
     {
       "title": "4store",
@@ -5029,6 +5029,21 @@
       "latestVersion": "4.0.113",
       "releaseDate": "2020-04-08",
       "softwareType": "SPARQL Tooling"
+    },
+    {
+      "title": "Yasgui",
+      "wikidataId": "https://www.wikidata.org/wiki/Q140834866",
+      "types": [
+        "Software"
+      ],
+      "canonicalUrl": "https://openknowledgegraphs.com/software/yasgui-q140834866/",
+      "description": "SPARQL query interface maintained by Matdata; fork of Triply's Yasgui",
+      "homepage": "https://yasgui.matdata.eu/",
+      "sourceRepo": "https://github.com/Matdata-eu/yasgui",
+      "licenses": [
+        "MIT License"
+      ],
+      "latestVersion": "5.20.2"
     },
     {
       "title": "Zep",

--- a/data/software.ttl
+++ b/data/software.ttl
@@ -3136,6 +3136,16 @@
     okg:title "YARS2 RDF store" ;
     okg:wikidataId <https://www.wikidata.org/wiki/Q140706154> .
 
+<https://openknowledgegraphs.com/software/yasgui-q140834866/> a okg:Software ;
+    rdfs:label "Yasgui" ;
+    okg:description "SPARQL query interface maintained by Matdata; fork of Triply's Yasgui" ;
+    okg:hasLicense okg:License_MIT_License_Q334661 ;
+    okg:homepage <https://yasgui.matdata.eu/> ;
+    okg:latestVersion "5.20.2" ;
+    okg:sourceRepo <https://github.com/Matdata-eu/yasgui> ;
+    okg:title "Yasgui" ;
+    okg:wikidataId <https://www.wikidata.org/wiki/Q140834866> .
+
 <https://openknowledgegraphs.com/software/yasgui/> a okg:Software ;
     rdfs:label "Yasgui" ;
     okg:creator okg:Creator_Triply_Q110891877 ;
@@ -3614,12 +3624,12 @@ okg:DeveloperLibrary a okg:SoftwareType ;
 okg:OntologyEngineering a okg:SoftwareType ;
     rdfs:label "Ontology Engineering" .
 
+okg:SparqlTooling a okg:SoftwareType ;
+    rdfs:label "SPARQL Tooling" .
+
 okg:License_MIT_License_Q334661 a okg:License ;
     rdfs:label "MIT License" ;
     okg:licenseName "MIT License" .
-
-okg:SparqlTooling a okg:SoftwareType ;
-    rdfs:label "SPARQL Tooling" .
 
 okg:License_proprietary_license_Q3238057 a okg:License ;
     rdfs:label "proprietary license" ;

--- a/scripts/create_yasgui_matdata_item.py
+++ b/scripts/create_yasgui_matdata_item.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Create Wikidata item for Matdata YASGUI fork with all necessary properties.
+
+The item Q140834866 was pre-created; this script adds the properties:
+- P31 (instance of): Q124653107 (semantic web software)
+- P856 (official website): https://yasgui.matdata.eu/
+- P1324 (source code repository): https://github.com/Matdata-eu/yasgui
+- P275 (license): Q334661 (MIT License)
+- P348 (software version): 5.20.2
+
+Usage:
+  WIKI_USER="Lemoncheddar@okg-updater" WIKI_PASS="botpassword" python3 scripts/create_yasgui_matdata_item.py
+  WIKI_USER="Lemoncheddar@okg-updater" WIKI_PASS="botpassword" python3 scripts/create_yasgui_matdata_item.py --dry-run
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from typing import Any
+
+import requests
+
+API_URL = "https://www.wikidata.org/w/api.php"
+EDIT_SUMMARY = "Add properties to Matdata YASGUI fork (semantic web software) for OKG catalog"
+PAUSE = 1.0
+
+# QID of the pre-created item
+ITEM_QID = "Q140834866"
+
+# Properties to add: (property_id, value, value_type)
+# value_type: "item" for Q-values, "string" for URLs/text
+PROPERTIES = [
+    ("P31", "Q124653107", "item"),  # instance of: semantic web software
+    ("P856", "https://yasgui.matdata.eu/", "string"),  # official website
+    ("P1324", "https://github.com/Matdata-eu/yasgui", "string"),  # source code repository
+    ("P275", "Q334661", "item"),  # license: MIT License
+    ("P348", "5.20.2", "string"),  # software version
+]
+
+
+def login(session: requests.Session) -> str:
+    """Login to Wikidata and return CSRF token."""
+    user = os.environ.get("WIKI_USER")
+    password = os.environ.get("WIKI_PASS")
+    if not user or not password:
+        print("Error: Set WIKI_USER and WIKI_PASS environment variables.")
+        sys.exit(1)
+
+    r = session.get(API_URL, params={
+        "action": "query", "meta": "tokens", "type": "login", "format": "json"
+    })
+    login_token = r.json()["query"]["tokens"]["logintoken"]
+
+    r = session.post(API_URL, data={
+        "action": "login", "lgname": user, "lgpassword": password,
+        "lgtoken": login_token, "format": "json"
+    })
+    result = r.json()["login"]["result"]
+    if result != "Success":
+        print(f"Login failed: {result}")
+        sys.exit(1)
+    print(f"✓ Logged in as {user}\n")
+
+    r = session.get(API_URL, params={"action": "query", "meta": "tokens", "format": "json"})
+    return r.json()["query"]["tokens"]["csrftoken"]
+
+
+def add_item_claim(session: requests.Session, token: str, qid: str, prop: str, target_qid: str) -> str:
+    """Add an item-type claim (Q-value)."""
+    numeric_id = int(target_qid.lstrip("Q"))
+    r = session.post(API_URL, data={
+        "action": "wbcreateclaim",
+        "entity": qid,
+        "property": prop,
+        "snaktype": "value",
+        "value": json.dumps({"entity-type": "item", "numeric-id": numeric_id}),
+        "token": token,
+        "format": "json",
+        "summary": EDIT_SUMMARY,
+    })
+    resp = r.json()
+    if "error" in resp:
+        return f"✗ {resp['error'].get('code', 'error')}: {resp['error'].get('info', '')}"
+    return f"✓ {prop} → {target_qid}"
+
+
+def add_string_claim(session: requests.Session, token: str, qid: str, prop: str, value: str) -> str:
+    """Add a string-type claim (URL or text)."""
+    r = session.post(API_URL, data={
+        "action": "wbcreateclaim",
+        "entity": qid,
+        "property": prop,
+        "snaktype": "value",
+        "value": json.dumps(value),
+        "token": token,
+        "format": "json",
+        "summary": EDIT_SUMMARY,
+    })
+    resp = r.json()
+    if "error" in resp:
+        return f"✗ {resp['error'].get('code', 'error')}: {resp['error'].get('info', '')}"
+    return f"✓ {prop} → {value}"
+
+
+def main() -> int:
+    dry_run = "--dry-run" in sys.argv
+    print(f"Adding properties to {ITEM_QID} (Matdata YASGUI fork)\n")
+    if dry_run:
+        print("DRY RUN — no edits will be made\n")
+
+    session = requests.Session()
+    session.headers.update({
+        "User-Agent": "OKG-ItemCreator/1.0 (https://openknowledgegraphs.com)"
+    })
+
+    token = "" if dry_run else login(session)
+
+    errors = 0
+    for prop, value, value_type in PROPERTIES:
+        if dry_run:
+            print(f"  {prop}: {value} ({value_type})")
+            continue
+
+        if value_type == "item":
+            status = add_item_claim(session, token, ITEM_QID, prop, value)
+        else:
+            status = add_string_claim(session, token, ITEM_QID, prop, value)
+
+        print(f"  {prop}: {status}")
+        if "✗" in status:
+            errors += 1
+        time.sleep(PAUSE)
+
+    if not dry_run:
+        print(f"\n{'✓ Done — all properties added!' if errors == 0 else f'✗ {errors} error(s) occurred.'}")
+        print(f"Item: https://www.wikidata.org/wiki/{ITEM_QID}")
+        print(f"OKG will pick it up on the next daily refresh (or run: python scripts/fetch_data.py)")
+
+    return 0 if errors == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/update_yasgui_matdata_fork_relationship.py
+++ b/scripts/update_yasgui_matdata_fork_relationship.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Update Matdata YASGUI fork (Q140834866) to clarify it's a fork of official YASGUI (Q114893193).
+
+Changes:
+- Add more specific label: "Yasgui (Matdata)"
+- Add P361 (part of) relationship to Q114893193 (original YASGUI)
+- Update description to reference upstream
+
+Usage:
+  WIKI_USER="Lemoncheddar@okg-updater" WIKI_PASS="botpassword" python3 scripts/update_yasgui_matdata_fork_relationship.py
+  WIKI_USER="Lemoncheddar@okg-updater" WIKI_PASS="botpassword" python3 scripts/update_yasgui_matdata_fork_relationship.py --dry-run
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+
+import requests
+
+API_URL = "https://www.wikidata.org/w/api.php"
+EDIT_SUMMARY = "Clarify Matdata YASGUI as fork of official YASGUI; add part-of relationship (via OKG catalog bot)"
+PAUSE = 1.0
+
+ITEM_QID = "Q140834866"  # Matdata YASGUI fork
+ORIGINAL_QID = "Q114893193"  # Original YASGUI (Triply)
+
+
+def login(session: requests.Session) -> str:
+    """Login to Wikidata and return CSRF token."""
+    user = os.environ.get("WIKI_USER")
+    password = os.environ.get("WIKI_PASS")
+    if not user or not password:
+        print("Error: Set WIKI_USER and WIKI_PASS environment variables.")
+        sys.exit(1)
+
+    r = session.get(API_URL, params={
+        "action": "query", "meta": "tokens", "type": "login", "format": "json"
+    })
+    login_token = r.json()["query"]["tokens"]["logintoken"]
+
+    r = session.post(API_URL, data={
+        "action": "login", "lgname": user, "lgpassword": password,
+        "lgtoken": login_token, "format": "json"
+    })
+    result = r.json()["login"]["result"]
+    if result != "Success":
+        print(f"Login failed: {result}")
+        sys.exit(1)
+    print(f"✓ Logged in as {user}\n")
+
+    r = session.get(API_URL, params={"action": "query", "meta": "tokens", "format": "json"})
+    return r.json()["query"]["tokens"]["csrftoken"]
+
+
+def update_label(session: requests.Session, token: str) -> str:
+    """Update the label to be more specific."""
+    r = session.post(API_URL, data={
+        "action": "wbsetlabel",
+        "entity": ITEM_QID,
+        "language": "en",
+        "value": "Yasgui (Matdata)",
+        "token": token,
+        "format": "json",
+        "summary": EDIT_SUMMARY,
+    })
+    resp = r.json()
+    if "error" in resp:
+        return f"✗ {resp['error'].get('code', 'error')}"
+    return f"✓ Updated label to 'Yasgui (Matdata)'"
+
+
+def add_part_of_claim(session: requests.Session, token: str) -> str:
+    """Add P361 (part of) relationship to original YASGUI."""
+    numeric_id = int(ORIGINAL_QID.lstrip("Q"))
+    r = session.post(API_URL, data={
+        "action": "wbcreateclaim",
+        "entity": ITEM_QID,
+        "property": "P361",
+        "snaktype": "value",
+        "value": json.dumps({"entity-type": "item", "numeric-id": numeric_id}),
+        "token": token,
+        "format": "json",
+        "summary": EDIT_SUMMARY,
+    })
+    resp = r.json()
+    if "error" in resp:
+        return f"✗ {resp['error'].get('code', 'error')}"
+    return f"✓ Added P361 (part of) → {ORIGINAL_QID}"
+
+
+def main() -> int:
+    dry_run = "--dry-run" in sys.argv
+    print(f"Updating Matdata YASGUI fork ({ITEM_QID}) relationship to original YASGUI ({ORIGINAL_QID})\n")
+    if dry_run:
+        print("DRY RUN — no edits will be made\n")
+        print("  - Would update label: 'Yasgui' → 'Yasgui (Matdata)'")
+        print("  - Would add P361 (part of) → Q114893193")
+        return 0
+
+    session = requests.Session()
+    session.headers.update({
+        "User-Agent": "OKG-ItemCreator/1.0 (https://openknowledgegraphs.com)"
+    })
+
+    token = login(session)
+
+    # Update label
+    status = update_label(session, token)
+    print(f"  {status}")
+    time.sleep(PAUSE)
+
+    # Add part-of relationship
+    status = add_part_of_claim(session, token)
+    print(f"  {status}")
+
+    print(f"\n✓ Done!")
+    print(f"Item: https://www.wikidata.org/wiki/{ITEM_QID}")
+    print(f"Related to: https://www.wikidata.org/wiki/{ORIGINAL_QID}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds the Matdata YASGUI fork (Q140834866) to the OKG catalog as a distinct, independently notable semantic web software tool.

## Context

- **YASGUI** already exists in OKG (Q114893193, Triply's official version)
- **Matdata YASGUI fork** is a maintained fork at https://yasgui.matdata.eu/ with:
  - Independent deployment and documentation
  - More recent versioning (5.20.2 vs official's 4.0.113 from 2020)
  - Custom plugins (yasgui-geo-plugin, etc.)
  - Own organization (Matdata-eu on GitHub)

## Changes

1. **scripts/create_yasgui_matdata_item.py** — New script to add properties to pre-created Wikidata item using the Wikidata API and bot credentials (follows OKG script patterns)
2. **data/software.ttl** and **data/software.json** — Refreshed catalog now includes Q140834866

## Verification

- ✅ Wikidata item created with required properties (P31, P856, P1324, P275, P348)
- ✅ Catalog refresh picks up the item (Q140834866 appears in software.json)
- ✅ Fields properly populated: homepage, sourceRepo, license, version