### PR TITLE
Fix false-positive soft-404 detection in link checker

### DIFF
--- a/scripts/generate_pages.py
+++ b/scripts/generate_pages.py
@@ -60,7 +60,8 @@ PARKED_SIGNALS = [
 SOFT_404_SIGNALS = [
     "page not found", "404 not found", "not found</",
     "page doesn't exist", "page does not exist",
-    "has been removed", "error 404",
+    "this page has been removed", "the page has been removed",
+    "error 404",
 ]
 
 


### PR DESCRIPTION
## Summary
- The `SOFT_404_SIGNALS` substring match `"has been removed"` was too broad — it flagged legitimate pages as dead links whenever that phrase appeared anywhere in the page body, even in unrelated boilerplate/changelog text.
- Concretely: OWL's Wikidata-listed homepage (`w3.org/TR/owl2-overview/`) was being pruned from OKG because the spec's own "Changes Since Proposed Recommendation" changelog contains the sentence "...has been removed from the 'Status of this Document' section" — nothing to do with the page being broken.
- Narrowed the signal to `"this page has been removed"` / `"the page has been removed"`, which still catches genuine soft-404 boilerplate without the false positive.

## Test plan
- [x] Verified the OWL spec page (43,840 bytes) no longer trips any `SOFT_404_SIGNALS` entry with the new phrasing
- [x] Confirmed the page is genuinely live (200, real content) via direct curl
- [ ] Rerun "Update Catalog Data" after merge and confirm OWL's page resolves on openknowledgegraphs.com