### PR TITLE
fix(ci): install root requirements.txt in update-jobs.yml

### DIFF
--- a/.github/workflows/update-jobs.yml
+++ b/.github/workflows/update-jobs.yml
@@ -46,10 +46,15 @@ jobs:
         with:
           python-version: "3.12"
           cache: "pip"
-          cache-dependency-path: prototypes/kg-jobs/requirements.txt
+          cache-dependency-path: |
+            prototypes/kg-jobs/requirements.txt
+            requirements.txt
 
       - name: Install kg-jobs prototype dependencies
         run: python -m pip install --upgrade pip && pip install -r requirements.txt
+
+      - name: Install root catalog_snapshot.py dependencies
+        run: pip install -r ../../requirements.txt
 
       - name: Restore last committed snapshot into runtime/
         run: |


### PR DESCRIPTION
## Summary
- Every hourly "Update KG Jobs Data" run has failed since the manifest-isolation fix landed (starting `2026-08-18T23:26:22Z`): the new "Regenerate and verify the data/jobs/ manifest" step calls the root `scripts/catalog_snapshot.py`, which imports `jsonschema` — but the workflow only installs `prototypes/kg-jobs/requirements.txt`, which doesn't include it.
- Fixes by also installing the root `requirements.txt` (which has `jsonschema`, plus consistent `rdflib`/`requests`/`pyshacl` pins) before the manifest step runs.
- No data corruption occurred: the failure happens before the "Commit and push" step, so nothing broken landed on `main` — Jooble's own refresh is separately gated by its 6h `minRefreshIntervalSeconds` regardless.

## Test plan
- [x] Confirmed `jsonschema` is present in root `requirements.txt` but absent from `prototypes/kg-jobs/requirements.txt`
- [x] Confirmed the failed run (`32197173795`) errored with `ModuleNotFoundError: No module named 'jsonschema'` at the manifest step, before any commit
- [x] Confirmed with a venv containing both requirements files that `catalog_snapshot.py`'s imports resolve cleanly