### PR TITLE
feat(site): add mobile card layout for the Jobs tab

### DIFF
--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.0.0",
-  "generationId": "20260818T211459Z-d63a60b27bee",
+  "generationId": "20260818T211459Z-622f62f466d0",
   "startedAt": "2026-08-18T21:08:32Z",
   "sourceRetrievedAt": "2026-08-18T21:14:14Z",
   "completedAt": "2026-08-18T21:14:59Z",
@@ -74,7 +74,7 @@
     },
     {
       "path": "site/app.js",
-      "sha256": "8d96b863e57c6f10c30d908d9dd284308d6a222d26853d044df9750bd8791788"
+      "sha256": "d17d3635df37d9811652e11623a895541159109aa039d9b1be230da6a0708d11"
     },
     {
       "path": "site/favicon.png",
@@ -86,7 +86,7 @@
     },
     {
       "path": "site/index.html",
-      "sha256": "54c30bdd9557794348bf2279eb6fd8a75caaaa6fd656b68040d5c0b041d3849c"
+      "sha256": "f551e36dfe411516c62792bcace31012469599d11179954d27281978ef07d741"
     },
     {
       "path": "site/llms.txt",
@@ -110,7 +110,7 @@
     },
     {
       "path": "site/style.css",
-      "sha256": "ca1849e6d6f2aa9ea745913b5ef3966bd82677f214ed05a5c09394088f0fee77"
+      "sha256": "64f1c4821ea92a4c77c2785bef1f8e2d73a680583812445abf20c9b69e1f7923"
     },
     {
       "path": "sources.ttl",

--- a/site/app.js
+++ b/site/app.js
@@ -50,9 +50,7 @@
   const CARD_CONTAINER_IDS = {
     ontologies: "ontologies-cards",
     software: "software-cards",
-    // Jobs deliberately has no mobile card layout in this first pass --
-    // renderCards() no-ops when it can't find a container for the tab, and
-    // render() forces the table view for jobs regardless of viewport.
+    jobs: "jobs-cards",
   };
 
   const COLUMN_COUNTS = {
@@ -1129,6 +1127,65 @@
     return card;
   }
 
+  function renderJobCard(item) {
+    const card = document.createElement("article");
+    card.className = "card";
+    card.dataset.record = "true";
+
+    const title = document.createElement("h3");
+    title.textContent = item.title;
+    card.appendChild(title);
+
+    appendCardMetaLine(card, "Employer", item.hiringOrganization || "");
+    appendCardMetaLine(card, "Location", item.location || "");
+    appendCardMetaLine(card, "Remote", jobRemoteLabel(item));
+    appendCardMetaLine(
+      card,
+      "Posted",
+      item.datePosted ? formatDate(item.datePosted) : ""
+    );
+    appendCardMetaLine(card, "Salary", item.salary || "");
+
+    const links = document.createElement("p");
+    links.className = "card-links";
+    if (item.canonicalUrl) {
+      links.appendChild(
+        createLink(item.canonicalUrl, "View posting", {
+          linkType: "job_posting",
+          resourceTitle: item.title,
+          tab: "jobs",
+        })
+      );
+      // See the matching comment in renderJobRow: Arbeitnow is the one
+      // source whose canonicalUrl can point off arbeitnow.com, so it needs
+      // a separate attribution link to satisfy its API terms.
+      const canonicalHost = extractHost(item.canonicalUrl);
+      const attributionHost = extractHost(item.sourceAttributionUrl);
+      if (
+        item.sourceAttributionUrl &&
+        canonicalHost &&
+        attributionHost &&
+        canonicalHost !== attributionHost
+      ) {
+        links.appendChild(document.createTextNode(" | "));
+        links.appendChild(
+          createLink(
+            item.sourceAttributionUrl,
+            `Source: ${item.sourceName || "original board"}`,
+            {
+              linkType: "source_attribution",
+              resourceTitle: item.title,
+              tab: "jobs",
+            }
+          )
+        );
+      }
+      card.appendChild(links);
+    }
+
+    return card;
+  }
+
   function renderTable(items) {
     const tableBody = document.getElementById(TABLE_BODY_IDS[state.tab]);
     if (!tableBody) {
@@ -1184,7 +1241,12 @@
       return;
     }
 
-    const cardRenderer = state.tab === "ontologies" ? renderOntologyCard : renderSoftwareCard;
+    const cardRenderer =
+      state.tab === "ontologies"
+        ? renderOntologyCard
+        : state.tab === "jobs"
+        ? renderJobCard
+        : renderSoftwareCard;
     items.forEach((item) => {
       cardContainer.appendChild(cardRenderer(item));
     });
@@ -1313,11 +1375,8 @@
     });
   }
 
-  // Jobs has no mobile card layout in this first pass (see CARD_CONTAINER_IDS),
-  // so it always renders as a table -- renderCards() would silently no-op
-  // for it and leave the panel blank on narrow viewports otherwise.
   function shouldRenderCards() {
-    return isCardView() && state.tab !== "jobs";
+    return isCardView();
   }
 
   function render() {

--- a/site/index.html
+++ b/site/index.html
@@ -318,6 +318,7 @@
             <tbody id="jobs-table-body"></tbody>
           </table>
         </div>
+        <div id="jobs-cards" class="cards" aria-label="Job posting cards"></div>
       </section>
 
       <nav id="catalog-pagination" class="pagination" aria-label="Catalog pages" hidden>

--- a/site/style.css
+++ b/site/style.css
@@ -489,14 +489,6 @@ a:hover {
     display: grid;
     grid-template-columns: 1fr;
   }
-
-  /* Jobs has no mobile card layout in this first pass, so its table stays
-     visible (horizontally scrollable via .table-shell) instead of the panel
-     going blank the way it would if it inherited the table-hiding rule
-     above meant for tabs that do have a card fallback. */
-  [data-panel="jobs"] .table-shell {
-    display: block;
-  }
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- Jobs was the one tab still rendering as a horizontally-scrollable table on mobile (<=760px) -- Ontologies and Software both already had a stacked card layout as a mobile fallback.
- Adds `renderJobCard()` (mirrors `renderJobRow()`'s fields: employer, location, remote, posted, salary, posting link, and the Arbeitnow attribution-link fallback), wires `jobs` into `CARD_CONTAINER_IDS` and `renderCards()`'s renderer dispatch, adds the `#jobs-cards` container to `index.html`, and removes the CSS override that had forced the jobs table to stay visible (and horizontally scrollable) on mobile.
- Desktop table view is untouched.

## Test plan
- [x] `node --test tests/catalog_browser.test.js` -- 6/6 passed
- [x] `pytest tests/test_catalog_browser.py` -- passed
- [x] Verified live in a 390x844 mobile viewport: Jobs tab now shows stacked cards identical in style to Ontologies/Software, no horizontal scrolling
- [x] Verified desktop (1280px) table view is unchanged