### PR TITLE
fix(ci): stage data/jobs before regenerating its manifest

### DIFF
--- a/.github/workflows/update-jobs.yml
+++ b/.github/workflows/update-jobs.yml
@@ -116,10 +116,20 @@ jobs:
 
       - name: Detect published snapshot changes
         id: changes
+        # Stages data/jobs here, before the manifest step below, not just at
+        # commit time: deployed_files() (which finalize-jobs/verify-jobs use
+        # to enumerate data/jobs/) filters to git-tracked files whenever it
+        # runs against a real checkout (see catalog_snapshot.py). A brand
+        # new file -- e.g. data/jobs/raw/<source>.json the first time a
+        # source ever runs -- would otherwise exist on disk but be silently
+        # excluded from the manifest for being untracked, then get included
+        # anyway once "Commit and push" staged it, producing a manifest that
+        # never matches what was actually committed.
         if: github.event_name != 'workflow_dispatch' || inputs.dry_run != true
         run: |
           cd ../..
-          if git diff --quiet -- data/jobs/jobs.json data/jobs/jobs.ttl data/jobs/run.json data/jobs/raw; then
+          git add data/jobs
+          if git diff --cached --quiet -- data/jobs/jobs.json data/jobs/jobs.ttl data/jobs/run.json data/jobs/raw; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"

--- a/data/jobs/manifest.json
+++ b/data/jobs/manifest.json
@@ -9,6 +9,10 @@
       "sha256": "9c62a85f2b7e504c4c4b7c5d715b7c71f837d2a6452abbd13f811d0f1c761919"
     },
     {
+      "path": "data/jobs/raw/adzuna.json",
+      "sha256": "7088b5e35bee4bdec0129f88bb8ced4e244dcb4fd53b5b926abe67ee8bddb605"
+    },
+    {
       "path": "data/jobs/raw/arbeitnow.json",
       "sha256": "15c8a2e52e4e8d55995b0a9e7239e70ffa37c2beeccf60669b873f8677cf8096"
     },
@@ -30,7 +34,7 @@
     }
   ],
   "completedAt": "2026-08-19T02:17:55Z",
-  "generationId": "20260819T021755Z-c1f3a5948c07",
+  "generationId": "20260819T021755Z-929c19a293c1",
   "schemaVersion": "1.0.0",
   "sourceRetrievedAt": "2026-08-19T02:17:48Z",
   "startedAt": "2026-08-19T02:17:38Z"


### PR DESCRIPTION
## Summary
- "Publish Catalog Generation" run 32208106738 failed at "Finalize and verify generation manifest" with `Jobs manifest verification failed for: artifacts, generationId.`
- Root cause: `deployed_files()` (used by `finalize-jobs`/`verify-jobs` to enumerate `data/jobs/`) filters to git-tracked files whenever it runs against a real checkout with a `.git` directory -- the core catalog pipeline never hits this because its `finalize`/`verify` run against a plain staging copy with no `.git`.
- `update-jobs.yml` runs `finalize-jobs` directly against the real checkout, so a brand-new file that had never existed before that run (`data/jobs/raw/adzuna.json`, Adzuna's first-ever refresh) was on disk but not yet `git add`ed when `finalize-jobs` ran. It got silently excluded from the manifest's artifact list, then got committed anyway once "Commit and push" ran its own `git add` a few steps later -- producing a manifest that never matched what was actually committed.
- Fix: move `git add data/jobs` into "Detect published snapshot changes", before the manifest step runs, so new files are already tracked by the time `deployed_files()` enumerates them.
- Also regenerates `data/jobs/manifest.json` to the correct content (same timestamps as the broken commit -- this is a coverage fix, not a new data generation).

## Test plan
- [x] Reproduced locally: checked out the broken commit in an isolated worktree, confirmed `verify-jobs` fails with the exact same error, confirmed re-running `finalize-jobs` fresh (files now tracked, since the worktree checkout already has them committed) fixes it
- [x] `pytest tests/ prototypes/kg-jobs/tests/` -- 426 passed
- [x] `python scripts/catalog_snapshot.py verify --root .` passes locally against the regenerated manifests