### PR TITLE
fix(catalog): let data/jobs/ changes trigger a full republish

### DIFF
--- a/scripts/catalog_snapshot.py
+++ b/scripts/catalog_snapshot.py
@@ -670,8 +670,8 @@ def substantive_changes(candidate: Path, baseline: Path) -> list[str]:
     if not (baseline / MANIFEST_PATH).is_file():
         return [MANIFEST_PATH]
     # data/jobs/ has its own independent manifest/refresh cadence (see
-    # CORE_MANIFEST_EXCLUDED_PREFIX) and is never regenerated as part of a
-    # catalog generation, so it is excluded here too -- diffing it pulls in
+    # CORE_MANIFEST_EXCLUDED_PREFIX) and is excluded from the RDF-aware
+    # fingerprinting below -- diffing it that way pulls in
     # normalized_artifact_fingerprint's RDF isomorphism check on jobs.ttl,
     # which is pathologically slow (verified: hung 24+ minutes live, and
     # locally, on a graph with 937 blank nodes from ~450 job postings).
@@ -682,6 +682,21 @@ def substantive_changes(candidate: Path, baseline: Path) -> list[str]:
         if normalized_artifact_fingerprint(candidate, relative) != normalized_artifact_fingerprint(
             baseline, relative
         ):
+            changed.append(relative)
+    # data/jobs/ must still be able to trigger a full republish -- that is
+    # the only thing that copies it into the live Pages artifact (see
+    # build_pages_artifact) -- or it can only ever reach production by
+    # coincidentally riding along with an unrelated Wikidata change (this
+    # happened in practice: the second "Publish Catalog Generation" run
+    # after a Jooble-only refresh found nothing to publish and silently
+    # skipped, because data/jobs/ was invisible to this function entirely).
+    # A raw byte hash avoids the RDF isomorphism cost above while still
+    # correctly detecting that something changed.
+    candidate_jobs = set(jobs_deployed_files(candidate, include_manifest=False))
+    baseline_jobs = set(jobs_deployed_files(baseline, include_manifest=False))
+    changed.extend(sorted(candidate_jobs ^ baseline_jobs))
+    for relative in sorted(candidate_jobs & baseline_jobs):
+        if sha256_file(candidate / relative) != sha256_file(baseline / relative):
             changed.append(relative)
     return sorted(set(changed))
 

--- a/tests/test_catalog_snapshot.py
+++ b/tests/test_catalog_snapshot.py
@@ -208,12 +208,19 @@ class JobsManifestIsolationTests(unittest.TestCase):
             with self.assertRaises(catalog_snapshot.SnapshotError):
                 catalog_snapshot.build_pages_artifact(self.root, Path(destination) / "out")
 
-    def test_substantive_changes_ignores_jobs_files(self):
+    def test_substantive_changes_detects_jobs_files_via_raw_byte_hash(self):
+        # data/jobs/ is excluded from the core manifest's own artifact list
+        # (see test_core_manifest_excludes_jobs_files) but must still be
+        # able to trigger a full republish, or it can only reach production
+        # by coincidentally riding along with an unrelated Wikidata change.
         finalize(self.root)
         candidate = self.root.parent / "candidate"
         shutil.copytree(self.root, candidate)
         write(candidate / "data/jobs/jobs.ttl", "@prefix ex: <https://example.test/> . ex:job ex:name \"Changed\" .\n")
-        self.assertEqual(catalog_snapshot.substantive_changes(candidate, self.root), [])
+        self.assertEqual(
+            catalog_snapshot.substantive_changes(candidate, self.root),
+            ["data/jobs/jobs.ttl"],
+        )
 
     def test_build_pages_includes_jobs_files_once_both_manifests_are_valid(self):
         finalize(self.root)


### PR DESCRIPTION
## Summary
- The PR #53 fix that excluded `data/jobs/` from `substantive_changes()` (to avoid the pathological RDF-isomorphism hang on `jobs.ttl`) went too far: it made `data/jobs/` entirely invisible to the "is there anything to publish" decision.
- Confirmed live: after triggering a Jooble-only refresh, the next "Publish Catalog Generation" run found no Wikidata changes, correctly determined there was nothing else to publish, and silently skipped the entire deploy — leaving the live site serving stale job data (still showing the pre-Jooble-refresh count) even though the run reported success.
- `data/jobs/` can currently only reach production by coincidentally riding along with an unrelated Wikidata catalog change — which is exactly what happened with Adzuna's first run, masking this gap until a jobs-only refresh exposed it.
- Fix: detect `data/jobs/` changes via a raw byte hash (`sha256_file`, not the RDF-aware `normalized_artifact_fingerprint` that caused the original hang) — cheap enough to be safe, sufficient to correctly trigger a republish.
- `data/manifest.json`'s own tracked artifact list is unaffected and still correctly excludes `data/jobs/` (via `core_deployed_files`) — this change only affects the "should we publish" signal, not what the core manifest tracks or hashes with the expensive RDF-aware method.

## Test plan
- [x] `pytest tests/test_catalog_snapshot.py` — 37 passed, including the updated test (now asserts jobs changes ARE detected, reversing the old assertion)
- [x] `pytest tests/test_catalog_snapshot.py prototypes/kg-jobs/tests/` — 123 passed
- [x] Confirmed this is not a re-introduction of the original hang: byte hashing doesn't parse or canonicalize RDF, unlike `normalized_artifact_fingerprint`