### PR TITLE
Drop dead Jooble /away/ links, keep only /desc/ hosted postings

### DIFF
--- a/prototypes/kg-jobs/scripts/jooble_adapter.py
+++ b/prototypes/kg-jobs/scripts/jooble_adapter.py
@@ -18,6 +18,23 @@ from live_sources import LivePipelineError, SourceConfig
 from remotive_adapter import canonicalize_url, html_to_text, _date_only
 
 _JOB_AGE_RE = re.compile(r"[?&]jobAge=(\d+)\b")
+_DESC_LINK_RE = re.compile(r"jooble\.org/desc/", re.IGNORECASE)
+
+
+def is_desc_link(link: str) -> bool:
+    """True for Jooble's own hosted job-description pages ("/desc/").
+
+    Verified live against a real sample of qualified postings: Jooble's
+    "/away/" links are outbound tracking redirects to wherever Jooble
+    originally scraped the listing from (often a secondary ad network like
+    appcast.io or experteer.com, per the "source" field in raw responses) --
+    every "/away/" link sampled had already gone dead. "/desc/" links are
+    pages Jooble hosts and serves itself with no redirect, and every one
+    sampled was still live. This is a link-shape filter, not a fetch
+    failure -- non-"/desc/" postings are dropped before normalization the
+    same way postings older than the freshness cutoff are.
+    """
+    return bool(_DESC_LINK_RE.search(link or ""))
 
 
 def job_age_days(link: str) -> int | None:
@@ -124,6 +141,10 @@ def records_from_payload(
             age = job_age_days(str(item.get("link") or ""))
             if age is not None and age > source.max_posting_age_days:
                 continue
+        # "/away/" outbound-redirect postings are dropped here too -- see
+        # is_desc_link's docstring for why, verified against live postings.
+        if isinstance(item, dict) and not is_desc_link(str(item.get("link") or "")):
+            continue
         normalized = normalize_jooble_job(item, source, retrieved_at, query)
         if normalized is None:
             raise LivePipelineError(

--- a/prototypes/kg-jobs/tests/test_live_normalization.py
+++ b/prototypes/kg-jobs/tests/test_live_normalization.py
@@ -13,7 +13,11 @@ from himalayas_adapter import records_from_payload as himalayas_records  # noqa:
 from live_records import classify_records, deduplicate  # noqa: E402
 from live_sources import LivePipelineError, load_source_registry  # noqa: E402
 from remotive_adapter import records_from_payload  # noqa: E402
-from jooble_adapter import job_age_days, records_from_payload as jooble_records  # noqa: E402
+from jooble_adapter import (  # noqa: E402
+    is_desc_link,
+    job_age_days,
+    records_from_payload as jooble_records,
+)
 from adzuna_adapter import records_from_payload as adzuna_records  # noqa: E402
 from live_sources import ADZUNA_PAGE_SIZE  # noqa: E402
 
@@ -262,7 +266,7 @@ def test_jooble_filters_postings_older_than_the_registry_cutoff():
                 "title": "Fresh Ontology Engineer",
                 "company": "Fresh Co",
                 "snippet": "Recently posted role.",
-                "link": "https://jooble.org/away/1?p=1&jobAge=10&rgn=-1",
+                "link": "https://jooble.org/desc/1?p=1&jobAge=10&rgn=-1",
                 "updated": "2026-08-17T00:00:00.0000000",
             },
             {
@@ -273,7 +277,7 @@ def test_jooble_filters_postings_older_than_the_registry_cutoff():
                 # is 206 days -- this is the real, verified discrepancy
                 # that motivated the filter, reproduced here directly.
                 "snippet": "This looks recent but is not.",
-                "link": "https://jooble.org/away/2?p=1&jobAge=206&rgn=-1",
+                "link": "https://jooble.org/desc/2?p=1&jobAge=206&rgn=-1",
                 "updated": "2026-08-10T00:00:00.0000000",
             },
         ],
@@ -281,6 +285,45 @@ def test_jooble_filters_postings_older_than_the_registry_cutoff():
     records, fetched, complete = jooble_records(payload, source, NOW, "ontology")
     assert fetched == 2  # both counted as fetched -- filtering is not a fetch failure
     assert [record["title"] for record in records] == ["Fresh Ontology Engineer"]
+
+
+def test_is_desc_link_recognizes_jooble_hosted_pages():
+    assert is_desc_link("https://jooble.org/desc/123?p=1&jobAge=10") is True
+    assert is_desc_link("https://jooble.org/away/123?p=1&jobAge=10") is False
+    assert is_desc_link("") is False
+    assert is_desc_link(None) is False
+
+
+def test_jooble_drops_away_links_keeping_only_desc_links():
+    source = load_source_registry(ROOT / "sources.ttl")["jooble"]
+    payload = {
+        "totalCount": 2,
+        "jobs": [
+            {
+                "id": 1,
+                "title": "Redirected Ontology Engineer",
+                "company": "Redirect Co",
+                "snippet": "Reached only via an outbound tracking redirect.",
+                # "/away/" links redirect off Jooble to wherever it scraped
+                # the listing from -- verified live to be frequently dead
+                # even at a low jobAge, so these are dropped regardless of
+                # freshness.
+                "link": "https://jooble.org/away/1?p=1&jobAge=5&rgn=-1",
+                "updated": "2026-08-17T00:00:00.0000000",
+            },
+            {
+                "id": 2,
+                "title": "Hosted Ontology Engineer",
+                "company": "Hosted Co",
+                "snippet": "Jooble hosts this description directly.",
+                "link": "https://jooble.org/desc/2?p=1&jobAge=5&rgn=-1",
+                "updated": "2026-08-17T00:00:00.0000000",
+            },
+        ],
+    }
+    records, fetched, complete = jooble_records(payload, source, NOW, "ontology")
+    assert fetched == 2  # both counted as fetched -- filtering is not a fetch failure
+    assert [record["title"] for record in records] == ["Hosted Ontology Engineer"]
 
 
 def _adzuna_job(**overrides):


### PR DESCRIPTION
## Summary
Jooble's API returns two link shapes in the `link` field: `/away/` outbound tracking redirects to wherever Jooble originally scraped a listing from, and `/desc/` pages it hosts and serves directly.

Verified live (real Chrome browser, not a script — Jooble sits behind a Cloudflare bot challenge that blocks plain HTTP requests) against a sample of 10 of the site's currently qualified Jooble postings:
- **8/8 `/away/` links were dead** — including one at `jobAge=1`, so Jooble's own posting-age signal doesn't predict staleness here.
- **2/2 `/desc/` links were live.**

`/away/` links mostly trace back to secondary ad networks (`appcast.io`, `experteer.com`, per the `source` field visible in raw Jooble API responses) which have a pay-per-click incentive to keep an ad clickable past when the role actually closes, rather than the employer's own ATS. `/desc/` pages, hosted by Jooble itself, don't have that failure mode.

## Change
`prototypes/kg-jobs/scripts/jooble_adapter.py`: `records_from_payload` now drops any posting whose link isn't a `/desc/` page, the same way postings older than the freshness cutoff are already dropped — a normal skip, not a fetch failure.

Already-published `/away/` records in `data/jobs/jobs.json` will age out naturally on the next scheduled `update-jobs.yml` run, since the pipeline only retains records present in the current fetch sample.

## Test plan
- [x] Added `test_is_desc_link_recognizes_jooble_hosted_pages` and `test_jooble_drops_away_links_keeping_only_desc_links`
- [x] Updated the existing age-cutoff test's fixtures to use `/desc/` links so it stays isolated to testing age filtering specifically
- [x] Full kg-jobs test suite (88 tests) passes