### PR TITLE
Fix missing LOINC links on job postings

### DIFF
--- a/data/jobs/jobs.json
+++ b/data/jobs/jobs.json
@@ -104452,6 +104452,13 @@
         "title": "Wikidata"
       },
       {
+        "canonicalUrl": "https://openknowledgegraphs.com/resource/geonames/",
+        "dataset": "resource",
+        "matchedPhrase": "GeoNames",
+        "qid": "Q830106",
+        "title": "GeoNames"
+      },
+      {
         "canonicalUrl": "https://openknowledgegraphs.com/resource/geosparql/",
         "dataset": "resource",
         "matchedPhrase": "GeoSPARQL",
@@ -106415,6 +106422,13 @@
         "title": "SNOMED CT"
       },
       {
+        "canonicalUrl": "https://openknowledgegraphs.com/resource/logical-observation-identifiers-names-and-codes/",
+        "dataset": "resource",
+        "matchedPhrase": "LOINC",
+        "qid": "Q502480",
+        "title": "Logical Observation Identifiers Names and Codes"
+      },
+      {
         "canonicalUrl": "https://openknowledgegraphs.com/resource/rxnorm/",
         "dataset": "resource",
         "matchedPhrase": "RxNorm",
@@ -106652,6 +106666,13 @@
         "matchedPhrase": "SNOMED CT",
         "qid": "Q1753883",
         "title": "SNOMED CT"
+      },
+      {
+        "canonicalUrl": "https://openknowledgegraphs.com/resource/logical-observation-identifiers-names-and-codes/",
+        "dataset": "resource",
+        "matchedPhrase": "LOINC",
+        "qid": "Q502480",
+        "title": "Logical Observation Identifiers Names and Codes"
       },
       {
         "canonicalUrl": "https://openknowledgegraphs.com/resource/rxnorm/",
@@ -106960,6 +106981,13 @@
         "matchedPhrase": "ICD-10",
         "qid": "Q45127",
         "title": "ICD-10"
+      },
+      {
+        "canonicalUrl": "https://openknowledgegraphs.com/resource/logical-observation-identifiers-names-and-codes/",
+        "dataset": "resource",
+        "matchedPhrase": "LOINC",
+        "qid": "Q502480",
+        "title": "Logical Observation Identifiers Names and Codes"
       },
       {
         "canonicalUrl": "https://openknowledgegraphs.com/resource/rxnorm/",
@@ -110433,6 +110461,13 @@
         "matchedPhrase": "SNOMED CT",
         "qid": "Q1753883",
         "title": "SNOMED CT"
+      },
+      {
+        "canonicalUrl": "https://openknowledgegraphs.com/resource/logical-observation-identifiers-names-and-codes/",
+        "dataset": "resource",
+        "matchedPhrase": "LOINC",
+        "qid": "Q502480",
+        "title": "Logical Observation Identifiers Names and Codes"
       },
       {
         "canonicalUrl": "https://openknowledgegraphs.com/resource/rxnorm/",

--- a/data/jobs/jobs.ttl
+++ b/data/jobs/jobs.ttl
@@ -75296,7 +75296,8 @@ kgjd:employer-zenjob a kgjobs:Employer,
     schema:jobLocation <https://openknowledgegraphs.com/jobs/live/job/himalayas-809f02b416650812/location> ;
     schema:jobLocationType "TELECOMMUTE" ;
     schema:keywords "SPARQL" ;
-    schema:mentions <https://openknowledgegraphs.com/resource/geosparql/>,
+    schema:mentions <https://openknowledgegraphs.com/resource/geonames/>,
+        <https://openknowledgegraphs.com/resource/geosparql/>,
         <https://openknowledgegraphs.com/resource/resource-description-framework/>,
         <https://openknowledgegraphs.com/resource/skos/>,
         <https://openknowledgegraphs.com/resource/web-ontology-language/>,
@@ -76712,6 +76713,7 @@ kgjd:employer-zenjob a kgjobs:Employer,
     schema:jobLocation <https://openknowledgegraphs.com/jobs/live/job/himalayas-bffd2503f5dccce9/location> ;
     schema:jobLocationType "TELECOMMUTE" ;
     schema:mentions <https://openknowledgegraphs.com/resource/icd-10/>,
+        <https://openknowledgegraphs.com/resource/logical-observation-identifiers-names-and-codes/>,
         <https://openknowledgegraphs.com/resource/rxnorm/>,
         <https://openknowledgegraphs.com/resource/snomed-ct/> ;
     schema:title "Clinical Informatics & Ontology Lead" ;
@@ -76864,7 +76866,8 @@ kgjd:employer-zenjob a kgjobs:Employer,
     schema:jobLocation <https://openknowledgegraphs.com/jobs/live/job/himalayas-c54c9b24c98a2ac3/location> ;
     schema:jobLocationType "TELECOMMUTE" ;
     schema:keywords "SPARQL" ;
-    schema:mentions <https://openknowledgegraphs.com/resource/resource-description-framework/>,
+    schema:mentions <https://openknowledgegraphs.com/resource/logical-observation-identifiers-names-and-codes/>,
+        <https://openknowledgegraphs.com/resource/resource-description-framework/>,
         <https://openknowledgegraphs.com/resource/rxnorm/>,
         <https://openknowledgegraphs.com/resource/snomed-ct/>,
         <https://openknowledgegraphs.com/resource/web-ontology-language/>,
@@ -77017,6 +77020,7 @@ kgjd:employer-zenjob a kgjobs:Employer,
     schema:jobLocationType "TELECOMMUTE" ;
     schema:keywords "SPARQL" ;
     schema:mentions <https://openknowledgegraphs.com/resource/icd-10/>,
+        <https://openknowledgegraphs.com/resource/logical-observation-identifiers-names-and-codes/>,
         <https://openknowledgegraphs.com/resource/resource-description-framework/>,
         <https://openknowledgegraphs.com/resource/rxnorm/>,
         <https://openknowledgegraphs.com/resource/skos/>,
@@ -79274,6 +79278,7 @@ kgjd:employer-zenjob a kgjobs:Employer,
     schema:jobLocationType "TELECOMMUTE" ;
     schema:keywords "SPARQL" ;
     schema:mentions <https://openknowledgegraphs.com/resource/icd-10/>,
+        <https://openknowledgegraphs.com/resource/logical-observation-identifiers-names-and-codes/>,
         <https://openknowledgegraphs.com/resource/resource-description-framework/>,
         <https://openknowledgegraphs.com/resource/rxnorm/>,
         <https://openknowledgegraphs.com/resource/shacl/>,

--- a/data/jobs/manifest.json
+++ b/data/jobs/manifest.json
@@ -2,11 +2,11 @@
   "artifacts": [
     {
       "path": "data/jobs/jobs.json",
-      "sha256": "fb320686ee61183f908eda0b759fbfbc6e2d81dc4ebf2f9722748633c213eac0"
+      "sha256": "693a1f9fa28f2e53dde3a57cb4419038f9790c78829c6bfbc03d2ad9d807b16d"
     },
     {
       "path": "data/jobs/jobs.ttl",
-      "sha256": "011a94118f0e1e6a76ac4d47c18b3f3ce2803d03d4139fe2afcc4b4d1ab4f919"
+      "sha256": "bc968b2b11d6b4e586e7de26da472a55247a683bb020d3e26ad9fd09ca5b8fe2"
     },
     {
       "path": "data/jobs/raw/adzuna.json",
@@ -33,8 +33,8 @@
       "sha256": "aaaf7ec5d35c1d464c227db8a47ade77b9670a158c6b251e333f957748d2f9d7"
     }
   ],
-  "completedAt": "2026-09-08T08:04:18Z",
-  "generationId": "20260908T080418Z-ca0368b3d1e5",
+  "completedAt": "2026-09-08T15:56:56Z",
+  "generationId": "20260908T155656Z-19cdf816a2b5",
   "schemaVersion": "1.0.0",
   "sourceRetrievedAt": "2026-09-08T07:48:20Z",
   "startedAt": "2026-09-08T07:48:08Z"

--- a/jobs/catalog-mention-policy.json
+++ b/jobs/catalog-mention-policy.json
@@ -3,6 +3,7 @@
   "shortAcronymAllowlist": [
     "DCAT",
     "FOAF",
+    "LOINC",
     "N3",
     "Neo4j",
     "OWL",


### PR DESCRIPTION
LOINC was present in the catalog but suppressed by the short-acronym matcher, so jobs mentioning it lacked a link to its resource page. Add LOINC to the case-sensitive allowlist and rebuild the jobs snapshot and manifest.

The rebuild adds LOINC links to four jobs, including the Ontology Expert posting. It also picks up one GeoNames link from the recently published catalog. Existing mentions are retained; job classifications, evidence, and job tags are unchanged.

Validation: 16 focused matcher/history tests pass; positive, lowercase, substring, and bare-ICD checks pass; the rebuild validates RDF and the jobs manifest. Full jobs suite: 327 passed. Transactional snapshot verification passed.

Part of #62. Does not close the remaining clinical-resource reviews.
