### PR TITLE
Respect Wikidata ranks when selecting software versions

### DIFF
--- a/scripts/fetch_data.py
+++ b/scripts/fetch_data.py
@@ -238,11 +238,14 @@ PREFIX p: <http://www.wikidata.org/prop/>
 PREFIX ps: <http://www.wikidata.org/prop/statement/>
 PREFIX pq: <http://www.wikidata.org/prop/qualifier/>
 
-SELECT ?item ?version ?pubDate
+PREFIX wikibase: <http://wikiba.se/ontology#>
+
+SELECT ?item ?version ?pubDate ?versionRank
 WHERE {{
 {class_union_clause(mappings, SOFTWARE_DATASET)}
   ?item p:{version_property} ?verStmt .
-  ?verStmt ps:{version_property} ?version .
+  ?verStmt ps:{version_property} ?version ; wikibase:rank ?versionRank .
+  FILTER(?versionRank != wikibase:DeprecatedRank)
   OPTIONAL {{ ?verStmt pq:{publication_date_property} ?pubDate . }}
 }}
 """
@@ -1007,7 +1010,7 @@ def parse_wikidata_datetime(raw_value: str | None) -> datetime | None:
 
 
 def pick_latest_version_rows(rows: list[dict]) -> dict[str, tuple[str, date | None]]:
-    by_item: dict[str, list[tuple[str, datetime | None]]] = {}
+    by_item: dict[str, list[tuple[str, datetime | None, str]]] = {}
 
     for row in rows:
         item_iri_raw = binding_value(row, "item")
@@ -1015,12 +1018,18 @@ def pick_latest_version_rows(rows: list[dict]) -> dict[str, tuple[str, date | No
         if not item_iri_raw or not version:
             continue
         item_iri = canonical_entity_iri(item_iri_raw)
+        rank = binding_value(row, "versionRank") or "http://wikiba.se/ontology#NormalRank"
+        if rank == "http://wikiba.se/ontology#DeprecatedRank":
+            continue
         pub_date = parse_wikidata_datetime(binding_value(row, "pubDate"))
-        by_item.setdefault(item_iri, []).append((version, pub_date))
+        by_item.setdefault(item_iri, []).append((version, pub_date, rank))
 
     results: dict[str, tuple[str, date | None]] = {}
     for item_iri, candidates in by_item.items():
-        with_dates = [candidate for candidate in candidates if candidate[1] is not None]
+        # Preferred claims take precedence even when a normal claim has a newer date.
+        preferred = [c for c in candidates if c[2] == "http://wikiba.se/ontology#PreferredRank"]
+        eligible = preferred or candidates
+        with_dates = [(version, dt) for version, dt, _ in eligible if dt is not None]
         if with_dates:
             # Keep version and release date from the same statement row.
             version, dt_value = max(with_dates, key=lambda item: (item[1], item[0]))  # type: ignore[arg-type]
@@ -1028,7 +1037,7 @@ def pick_latest_version_rows(rows: list[dict]) -> dict[str, tuple[str, date | No
             continue
 
         # Fallback when no publication-date qualifier exists on any version statement.
-        version = sorted((candidate[0] for candidate in candidates), reverse=True)[0]
+        version = sorted((candidate[0] for candidate in eligible), reverse=True)[0]
         results[item_iri] = (version, None)
 
     return results

--- a/tests/test_software_version_ranks.py
+++ b/tests/test_software_version_ranks.py
@@ -1,0 +1,75 @@
+import sys
+import unittest
+from datetime import date
+from pathlib import Path
+from unittest.mock import patch
+
+from rdflib import Graph
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'scripts'))
+import fetch_data
+
+
+def row(version, rank='NormalRank', published=None, qid='Q141112433'):
+    result = {'item': {'value': 'http://www.wikidata.org/entity/' + qid},
+              'version': {'value': version},
+              'versionRank': {'value': 'http://wikiba.se/ontology#' + rank}}
+    if published:
+        result['pubDate'] = {'value': published + 'T00:00:00Z'}
+    return result
+
+
+class SoftwareVersionRanks(unittest.TestCase):
+    def test_query_projects_ranks_and_excludes_deprecated_claims(self):
+        graph = Graph().parse(data='''
+            @prefix wd: <http://www.wikidata.org/entity/> .
+            @prefix p: <http://www.wikidata.org/prop/> .
+            @prefix ps: <http://www.wikidata.org/prop/statement/> .
+            @prefix wb: <http://wikiba.se/ontology#> .
+            wd:Q141112433 p:P348 [ ps:P348 "2.0.16"; wb:rank wb:PreferredRank ],
+                [ ps:P348 "2.2.0.16"; wb:rank wb:NormalRank ],
+                [ ps:P348 "99"; wb:rank wb:DeprecatedRank ] .
+        ''', format='turtle')
+        with patch.object(fetch_data, 'wikidata_property', side_effect=['P348', 'P577']), \
+             patch.object(fetch_data, 'class_union_clause', return_value='VALUES ?item { wd:Q141112433 }'):
+            query = fetch_data.build_software_version_query(None)
+        results = graph.query(query)
+        bindings = [{'item': {'value': str(r.item)}, 'version': {'value': str(r.version)},
+                     'versionRank': {'value': str(r.versionRank)}} for r in results]
+        self.assertEqual({r['version']['value'] for r in bindings}, {'2.0.16', '2.2.0.16'})
+        self.assertEqual(self.select(bindings), ('2.0.16', None))
+
+    def select(self, rows):
+        return fetch_data.pick_latest_version_rows(rows)['http://www.wikidata.org/entity/Q141112433']
+
+    def test_raptor_preferred_release_beats_imported_tag_on_same_date(self):
+        rows = [row('2.0.16', 'PreferredRank', '2023-03-01'),
+                row('2.2.0.16', published='2023-03-01')]
+        for ordered in (rows, list(reversed(rows))):
+            self.assertEqual(self.select(ordered), ('2.0.16', date(2023, 3, 1)))
+
+    def test_preferred_without_date_beats_newer_normal_and_deprecated(self):
+        self.assertEqual(self.select([row('1', 'PreferredRank'),
+                                      row('2', published='2026-01-01'),
+                                      row('3', 'DeprecatedRank', '2027-01-01')]), ('1', None))
+
+    def test_multiple_preferred_preserve_version_date_pair(self):
+        self.assertEqual(self.select([row('1', 'PreferredRank', '2024-01-01'),
+                                      row('2', 'PreferredRank', '2025-01-01')]),
+                         ('2', date(2025, 1, 1)))
+
+    def test_normal_fallback_and_per_item_rank_selection(self):
+        rows = [row('1', published='2024-01-01'), row('2', published='2025-01-01'),
+                row('99', 'DeprecatedRank', '2026-01-01'),
+                row('4', 'PreferredRank', qid='Q1')]
+        self.assertEqual(self.select(rows), ('2', date(2025, 1, 1)))
+        self.assertEqual(fetch_data.pick_latest_version_rows([row('1', 'DeprecatedRank')]), {})
+
+    def test_undated_and_legacy_rows_keep_existing_fallback(self):
+        legacy = row('2')
+        del legacy['versionRank']
+        self.assertEqual(self.select([row('1'), legacy]), ('2', None))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Raptor currently appears in OKG as version `2.2.0.16` even though Wikidata prefers the official `2.0.16` release. The version query drops rank information, and equal release dates let lexical ordering choose the normal-ranked alternative.

Fetch version ranks, exclude deprecated claims, and select preferred claims before applying the existing date/version tie-breaking. Items without preferred versions retain the normal-claim fallback, with version and release date kept together.

Validation: all 194 root tests passed before the final query integration test; all six focused version tests pass, including the executed RDF/SPARQL query, Raptor regression, multiple preferred values, normal fallback, deprecated-only input, and input-order independence. `git diff --check` passed. Generated catalog files are unchanged; publication must refresh from Wikidata after merge.

Related to #49; does not close it automatically. Redland’s separately approved Wikidata rank correction is already verified at [revision 2542434377](https://www.wikidata.org/w/index.php?title=Q7306020&diff=2542434377). Both resources still need post-publication verification.
