### PR TITLE
Fix slow Workday scrapes and retain timeout diagnostics

### DIFF
--- a/jobs/README.md
+++ b/jobs/README.md
@@ -135,6 +135,18 @@ worst-case budget, leaving 12 minutes of headroom inside the 180-minute timeout.
 contract is in
 `audits/task42-nightly-operational-plan.json`.
 
+Workday sources reuse one session for listing pages and at most three separate,
+thread-owned sessions for job details. Detail output remains sorted, and a failed
+request (including HTTP 429) stops new detail requests and fails the source; no
+incomplete result is published and no automatic retries consume uncounted requests.
+The source's existing request, response-size, record and 720-second limits remain
+in effect. Each nightly source result includes `diagnostics` when available:
+Workday phase, discovered count, completed requests, and last request timing/status.
+Failure fields survive later in-flight successes. The parent copies the last atomic
+progress snapshot into `nightly-run.json` before deleting worker files, including
+when it terminates a source at its deadline. `pipeline-after-fetch` means HTTP
+collection finished; the remaining time is spent validating and building the source.
+
 First-party normalized snapshots and raw payloads are restored and saved through
 a private Actions cache so isolated failures on a later ephemeral runner retain
 their previous evidence. They are also uploaded as a 30-day diagnostic artifact,

--- a/jobs/scripts/first_party_sources.py
+++ b/jobs/scripts/first_party_sources.py
@@ -6,6 +6,9 @@ import hashlib
 import html
 import json
 import re
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -17,6 +20,8 @@ from urllib.parse import parse_qsl, urlencode, urljoin, urlparse, urlunparse
 import requests
 from rdflib import Graph, Namespace
 from rdflib.namespace import DCTERMS, RDF
+
+import source_progress
 
 ROOT = Path(__file__).resolve().parent.parent
 REPO_ROOT = ROOT.parent
@@ -3712,7 +3717,48 @@ def _bounded_request_batches(
     return batches
 
 
+def _workday_request(source, session, method, endpoint, **kwargs):
+    _https_exact_host(endpoint, source.allowed_host, "Workday endpoint")
+    started = time.monotonic()
+    source_progress.report(lastStartedPath=urlparse(endpoint).path)
+    response = None
+    try:
+        response = session.request(
+            method, endpoint, timeout=source.timeout_seconds,
+            allow_redirects=False, stream=True,
+            headers={"User-Agent": "OKG-first-party-jobs/1.0 (+https://openknowledgegraphs.com/)"},
+            **kwargs,
+        )
+        body = _response_body(source, response)
+        source_progress.report(completed=True)
+        return body
+    except (requests.RequestException, FirstPartySourceError) as exc:
+        source_progress.report(
+            failedPath=urlparse(endpoint).path,
+            failureType=type(exc).__name__,
+            failureHttpStatus=getattr(response, "status_code", None),
+            failureRetryAfter=response.headers.get("Retry-After") if response is not None else None,
+        )
+        if isinstance(exc, FirstPartySourceError):
+            raise
+        raise FirstPartySourceError(f"{source.key} request failed: {type(exc).__name__}") from exc
+    finally:
+        if response is not None:
+            response.close()
+        source_progress.report(
+            lastFinishedPath=urlparse(endpoint).path,
+            lastRequestSeconds=round(time.monotonic() - started, 3),
+            lastHttpStatus=getattr(response, "status_code", None),
+            retryAfter=response.headers.get("Retry-After") if response is not None else None,
+        )
+
+
 def _fetch_workday(source: FirstPartySource) -> dict:
+    with requests.Session() as session:
+        return _fetch_workday_with_session(source, session)
+
+
+def _fetch_workday_with_session(source: FirstPartySource, session) -> dict:
     parsed = urlparse(source.endpoint)
     target = urlunparse(parsed._replace(query=""))
     query = dict(parse_qsl(parsed.query, keep_blank_values=True))
@@ -3726,28 +3772,14 @@ def _fetch_workday(source: FirstPartySource) -> dict:
     while total is None or offset < total:
         if len(listings) + 1 > source.max_requests_per_run:
             raise FirstPartySourceError("Workday listing pagination exceeds its request cap")
-        try:
-            response = requests.post(
-                target,
-                json={
-                    "appliedFacets": facets,
-                    "limit": page_size,
-                    "offset": offset,
-                    "searchText": search_text,
-                },
-                timeout=source.timeout_seconds,
-                allow_redirects=False,
-                headers={
-                    "Content-Type": "application/json",
-                    "User-Agent": "OKG-first-party-jobs/1.0 (+https://openknowledgegraphs.com/)",
-                },
-                stream=True,
-            )
-        except requests.RequestException as exc:
-            raise FirstPartySourceError(
-                f"{source.key} request failed: {type(exc).__name__}"
-            ) from exc
-        body = _response_body(source, response)
+        source_progress.report(
+            phase="workday-listings", listingPages=len(listings),
+            discoveredDetails=len(discovered),
+        )
+        body = _workday_request(source, session, "POST", target, json={
+            "appliedFacets": facets, "limit": page_size,
+            "offset": offset, "searchText": search_text,
+        })
         try:
             page = json.loads(body.decode("utf-8-sig"))
         except (UnicodeDecodeError, json.JSONDecodeError) as exc:
@@ -3785,16 +3817,47 @@ def _fetch_workday(source: FirstPartySource) -> dict:
         len(listings), len(discovered), source.max_requests_per_batch
     )
     base_path = parsed.path.removesuffix("/jobs")
-    for external_path in sorted(discovered):
-        detail_url = urlunparse(parsed._replace(
-            path=f"{base_path}{external_path}", query=""
-        ))
-        body = _fetch_body(source, detail_url)
-        try:
-            detail = json.loads(body.decode("utf-8-sig"))
-        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-            raise FirstPartySourceError("Workday detail returned malformed JSON") from exc
-        details.append({"externalPath": external_path, "payload": detail})
+    paths = sorted(discovered)
+    source_progress.report(
+        phase="workday-details", listingPages=len(listings), discoveredDetails=len(paths),
+    )
+    stopped = threading.Event()
+
+    def fetch_partition(partition):
+        # Sessions are owned by one worker, never shared across threads.
+        rows = []
+        with requests.Session() as detail_session:
+            try:
+                for external_path in partition:
+                    if stopped.is_set():
+                        break
+                    detail_url = urlunparse(parsed._replace(
+                        path=f"{base_path}{external_path}", query=""
+                    ))
+                    body = _workday_request(source, detail_session, "GET", detail_url)
+                    try:
+                        detail = json.loads(body.decode("utf-8-sig"))
+                    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                        raise FirstPartySourceError("Workday detail returned malformed JSON") from exc
+                    rows.append({"externalPath": external_path, "payload": detail})
+            except Exception:
+                # Includes 429: stop new requests and retain last-good, without
+                # hidden retries that would evade the reviewed request budget.
+                stopped.set()
+                raise
+        return rows
+
+    with ThreadPoolExecutor(max_workers=3) as pool:
+        futures = [
+            pool.submit(fetch_partition, paths[index::3])
+            for index in range(min(3, len(paths)))
+        ]
+        for future in as_completed(futures):
+            details.extend(future.result())
+    if len(details) != len(paths):
+        raise FirstPartySourceError("Workday detail collection is incomplete")
+    details.sort(key=lambda row: row["externalPath"])
+    source_progress.report(phase="pipeline-after-fetch", completedDetails=len(details))
     return {
         "listingPages": listings,
         "details": details,

--- a/jobs/scripts/source_progress.py
+++ b/jobs/scripts/source_progress.py
@@ -1,0 +1,40 @@
+"""Small, atomic worker diagnostics; never store response bodies or credentials."""
+import json
+import os
+import threading
+import time
+from pathlib import Path
+
+_lock = threading.Lock()
+_path = None
+_state = {}
+_started = 0.0
+
+
+def configure(path):
+    global _path, _state, _started
+    _path = Path(path)
+    _state = {}
+    _started = time.monotonic()
+    report(phase="pipeline")
+
+
+def report(*, completed=False, **fields):
+    if _path is None:
+        return
+    with _lock:
+        _state.update(fields)
+        if completed:
+            _state["completedRequests"] = _state.get("completedRequests", 0) + 1
+        _state["elapsedSeconds"] = round(time.monotonic() - _started, 3)
+        _path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = _path.with_suffix(".tmp")
+        temporary.write_text(json.dumps(_state), encoding="utf-8")
+        os.replace(temporary, _path)
+
+
+def read(path):
+    try:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None

--- a/jobs/scripts/task42_nightly.py
+++ b/jobs/scripts/task42_nightly.py
@@ -17,12 +17,15 @@ import shutil
 import sys
 import tempfile
 import time
+
 from math import ceil
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 REPO_ROOT = ROOT.parent
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import source_progress  # noqa: E402
 
 from career_discovery_monitor import (  # noqa: E402
     MAX_WORKERS as DISCOVERY_WORKERS,
@@ -147,6 +150,7 @@ def _atomic_json(path: Path, value) -> None:
 
 
 def _source_worker(source_key: str, output: str) -> None:
+    source_progress.configure(Path(output).with_suffix(".progress.json"))
     result = {"error": None, "rawPayload": None, "run": None}
     # ``publish_snapshot`` recovers stale ``.kg-jobs-live-*`` stages by
     # scanning the runtime's parent. Give every concurrent worker an exclusive
@@ -226,6 +230,8 @@ def execute_process_batch(
             continue
         outcome["status"] = "fetched" if not outcome.get("error") else "fetch-failure"
         outcomes[key] = outcome
+    for key, outcome in outcomes.items():
+        outcome["diagnostics"] = source_progress.read(paths[key].with_suffix(".progress.json"))
     return outcomes
 
 
@@ -385,6 +391,7 @@ def run_nightly(
                 else:
                     source_results.append({
                         "sourceKey": key,
+                        **({"diagnostics": outcome["diagnostics"]} if outcome.get("diagnostics") else {}),
                         "status": "refreshed",
                         "error": None,
                         "fetchedCount": run["fetchedCount"],
@@ -403,6 +410,7 @@ def run_nightly(
                     "retained-last-good" if had_last_good else "isolated-failure"
                 ),
                 "error": str(error),
+                **({"diagnostics": outcome["diagnostics"]} if outcome.get("diagnostics") else {}),
             })
 
         monitor = monitor_runner(

--- a/jobs/tests/test_task42_remaining_sources.py
+++ b/jobs/tests/test_task42_remaining_sources.py
@@ -268,8 +268,16 @@ def test_workday_fetch_uses_exact_facet_and_bounded_cxs_detail_paths(monkeypatch
         calls.append(("GET", url, None))
         return Response(payload["details"][0]["payload"])
 
-    monkeypatch.setattr(fps.requests, "post", fake_post)
-    monkeypatch.setattr(fps.requests, "get", fake_get)
+    class Session:
+        def __enter__(self):
+            return self
+        def __exit__(self, *args):
+            pass
+        def request(self, method, url, **kwargs):
+            response = fake_post(url, **kwargs) if method == "POST" else fake_get(url, **kwargs)
+            response.close = lambda: None
+            return response
+    monkeypatch.setattr(fps.requests, "Session", Session)
     live_payload = fps.fetch_source(source)
     assert len(fps.records_from_payload(live_payload, source)) == 1
     assert calls[0] == (
@@ -332,8 +340,16 @@ def test_large_workday_source_uses_explicit_bounded_request_batches(monkeypatch)
             "title": f"Role {index}",
         }})
 
-    monkeypatch.setattr(fps.requests, "post", fake_post)
-    monkeypatch.setattr(fps.requests, "get", fake_get)
+    class Session:
+        def __enter__(self):
+            return self
+        def __exit__(self, *args):
+            pass
+        def request(self, method, url, **kwargs):
+            response = fake_post(url, **kwargs) if method == "POST" else fake_get(url, **kwargs)
+            response.close = lambda: None
+            return response
+    monkeypatch.setattr(fps.requests, "Session", Session)
     payload = fps.fetch_source(source)
     assert len(fps.records_from_payload(payload, source)) == total
     assert len(payload["requestBatches"]) == 3
@@ -1020,6 +1036,7 @@ def test_nightly_run_batches_due_sources_and_preserves_failed_source_last_good(t
                 "error": "simulated isolated timeout" if key == retained_key else None,
                 "rawPayload": None if key == retained_key else fixture(key),
                 "status": "timed-out" if key == retained_key else "fetched",
+                "diagnostics": {"phase": "workday-details", "completedRequests": 42},
             }
             for key in batch
         }
@@ -1043,6 +1060,9 @@ def test_nightly_run_batches_due_sources_and_preserves_failed_source_last_good(t
 
     assert executed == [[retained_key]]
     by_source = {row["sourceKey"]: row for row in result["sourceResults"]}
+    assert by_source[retained_key]["diagnostics"]["completedRequests"] == 42
+    saved = json.loads((runtime / "nightly-run.json").read_text())
+    assert saved["sourceResults"][0]["diagnostics"]["phase"] == "workday-details"
     assert result["sourceFailures"] == 1
     assert by_source[retained_key]["status"] == "retained-last-good"
     assert (runtime / "sources" / f"{retained_key}.json").read_bytes() == retained_source

--- a/jobs/tests/test_workday_transport.py
+++ b/jobs/tests/test_workday_transport.py
@@ -1,0 +1,127 @@
+"""Exercise bounded Workday concurrency and timeout evidence without networking."""
+import json
+import multiprocessing
+import threading
+import time
+from pathlib import Path
+
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import pytest
+import first_party_sources as fps
+import source_progress
+import task42_nightly
+
+
+class Response:
+    is_redirect = False
+    is_permanent_redirect = False
+    headers = {}
+    status_code = 200
+
+    def __init__(self, payload):
+        self.body = json.dumps(payload).encode()
+        self.closed = False
+
+    def raise_for_status(self):
+        if self.status_code != 200:
+            raise fps.requests.HTTPError(response=self)
+
+    def iter_content(self, size):
+        yield self.body
+
+    def close(self):
+        self.closed = True
+
+
+def transport(monkeypatch, *, fail=False):
+    paths = [f"/job/test/Role_{index}" for index in range(9)]
+    sessions, responses = [], []
+    barrier = threading.Barrier(3, timeout=3)
+    lock = threading.Lock()
+    active = peak = 0
+
+    class Session:
+        def __init__(self):
+            self.owner = threading.get_ident()
+            self.calls = 0
+            self.closed = False
+            sessions.append(self)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            self.closed = True
+
+        def request(self, method, url, **kwargs):
+            nonlocal active, peak
+            assert threading.get_ident() == self.owner
+            assert kwargs["allow_redirects"] is False
+            self.calls += 1
+            if method == "POST":
+                response = Response({"total": len(paths), "jobPostings": [{"externalPath": path} for path in paths]})
+            else:
+                with lock:
+                    active += 1
+                    peak = max(peak, active)
+                if self.calls == 1:
+                    barrier.wait()
+                time.sleep(0.005 if url.endswith("Role_0") else 0.02)
+                response = Response({"jobPostingInfo": {"title": url}})
+                if fail and url.endswith("Role_0"):
+                    response.status_code = 429
+                    response.headers = {"Retry-After": "60"}
+                with lock:
+                    active -= 1
+            responses.append(response)
+            return response
+
+    monkeypatch.setattr(fps.requests, "Session", Session)
+    return paths, sessions, responses, lambda: peak
+
+
+def test_connections_reused_concurrency_bounded_and_output_sorted(monkeypatch):
+    paths, sessions, responses, peak = transport(monkeypatch)
+    source = fps.load_first_party_sources()["first-party-accenture"]
+    payload = fps.fetch_source(source)
+    assert [row["externalPath"] for row in payload["details"]] == sorted(paths)
+    assert peak() == 3
+    assert sorted(session.calls for session in sessions) == [1, 3, 3, 3]
+    assert all(session.closed for session in sessions)
+    assert all(response.closed for response in responses)
+
+
+def test_rate_limit_stops_new_details_and_preserves_failure(monkeypatch, tmp_path):
+    paths, sessions, responses, peak = transport(monkeypatch, fail=True)
+    source_progress.configure(tmp_path / "progress.json")
+    try:
+        with pytest.raises(fps.FirstPartySourceError, match="HTTP 429"):
+            fps.fetch_source(fps.load_first_party_sources()["first-party-accenture"])
+        assert sum(session.calls for session in sessions) <= 4
+        assert all(response.closed for response in responses)
+        evidence = source_progress.read(tmp_path / "progress.json")
+        assert evidence["failureHttpStatus"] == 429
+        assert evidence["failureRetryAfter"] == "60"
+        assert evidence["completedRequests"] == 3
+        assert evidence["lastHttpStatus"] == 200
+    finally:
+        source_progress._path = None
+
+
+def slow_worker(key, output):
+    source_progress.configure(Path(output).with_suffix(".progress.json"))
+    source_progress.report(phase="workday-details", completed=True, discoveredDetails=300)
+    time.sleep(10)
+
+
+def test_timeout_captures_progress_before_worker_cleanup(tmp_path):
+    result = task42_nightly.execute_process_batch(
+        ["slow-source"], tmp_path, source_timeout_seconds=0.2,
+        context=multiprocessing.get_context("fork"), worker=slow_worker,
+    )["slow-source"]
+    assert result["status"] == "timed-out"
+    assert result["rawPayload"] is None
+    assert result["diagnostics"]["phase"] == "workday-details"
+    assert result["diagnostics"]["completedRequests"] == 1


### PR DESCRIPTION
Accenture hit the 720-second source limit in [Update KG Jobs Data #206](https://github.com/SteveHedden/open-knowledge-graphs/actions/runs/34325987461). The nightly run retained its last-good snapshot, but the terminated worker left no progress evidence. Workday collection made every listing and detail request sequentially with a new HTTP session.

Reuse a session for listing pagination and fetch details with at most three workers, each owning its own reusable session. Preserve sorted output, host validation, completeness checks, all existing request/record/response limits, and the 720-second deadline. On a failed request, including HTTP 429, stop new requests and fail the source; retain last-good data rather than publishing partial results. No automatic retries are added.

Write atomic progress snapshots during Workday collection and copy them into the nightly report before worker cleanup, including after a timeout. Diagnostics distinguish listing collection, detail collection, and subsequent pipeline work, with request counts, timing, HTTP status and durable failure information.

Validation:
- Accenture-only live source pipeline completed locally in **255.59 seconds**: **16 listing pages, 306 complete job details, 322 requests, 267 qualified jobs**. HTTP collection finished in 199.10 seconds. No repository publication or workflow dispatch was performed.
- Focused tests cover session ownership/reuse, the concurrency bound, stable output order, HTTP 429 stopping new requests, error evidence surviving later successful requests, timeout diagnostics and last-good retention.
- **330 jobs tests and 195 root regression tests passed**; organization registry, qualification audit, snapshot verification and `git diff --check` passed.

The transport change applies to the shared Workday adapter. The live result is from a local machine; GitHub runner performance still needs observation after deployment.
