### PR TITLE
Rename Conditions and Outcomes catalog URL and preserve old links

### DIFF
--- a/scripts/catalog_snapshot.py
+++ b/scripts/catalog_snapshot.py
@@ -46,6 +46,8 @@ DEPLOYED_DIRECTORIES = ("data", "curation", "vocabularies", "site")
 DIRECTORY_TREE_PATHS = ("site/resource", "site/software")
 STAGING_SUPPORT_FILES = (
     "scripts/fetch_data.py",
+    "scripts/uri_migrations.py",
+    "validation/uri-migrations.json",
     "scripts/category_classifier.py",
     "scripts/related_resources.py",
     "scripts/recommendation_coverage.py",

--- a/scripts/fetch_data.py
+++ b/scripts/fetch_data.py
@@ -53,6 +53,7 @@ from related_resources import (
     diagnostics_document,
     write_diagnostics_atomic,
 )
+from uri_migrations import apply_migrations, load_migrations
 from wikidata_relationship_audit import DirectIriEdge, audit_document, truthy_item_edges
 
 WDQS_URL = "https://query.wikidata.org/sparql"
@@ -436,8 +437,8 @@ def slugify(text: str) -> str:
 
 def load_uri_registry() -> dict[str, dict[str, str]]:
     """Load the persistent QID -> slug registry. Once a slug is assigned to a
-    QID it is never reassigned, so a resource's URI never changes even before
-    it has a live page (see mint_resource_iri).
+    QID it is retained even before it has a live page (see mint_resource_iri).
+    Only explicit reviewed URI migrations may change an existing assignment.
     """
     if URI_REGISTRY_OUT.exists():
         with open(URI_REGISTRY_OUT, encoding="utf-8") as f:
@@ -451,7 +452,7 @@ def load_uri_registry() -> dict[str, dict[str, str]]:
         registry = {}
     registry.setdefault("resource", {})
     registry.setdefault("software", {})
-    return registry
+    return apply_migrations(registry, load_migrations(ROOT_DIR))
 
 
 def save_uri_registry(registry: dict[str, dict[str, str]]) -> None:
@@ -469,6 +470,7 @@ def assign_slugs(records: dict[str, ResourceRecord], dataset_key: str, registry:
     """
     dataset_registry = registry[dataset_key]
     used_slugs = set(dataset_registry.values())
+    used_slugs.update(r["from"] for r in load_migrations(ROOT_DIR) if r["dataset"] == dataset_key)
 
     pending = [
         record

--- a/scripts/generate_pages.py
+++ b/scripts/generate_pages.py
@@ -34,6 +34,8 @@ from recommendation_coverage import (
     qualifying_reasons_by_catalog,
 )
 
+from uri_migrations import active_redirects, load_migrations, write_redirects
+
 ROOT_DIR = Path(
     os.environ.get("OKG_CATALOG_ROOT", Path(__file__).resolve().parent.parent)
 ).resolve()
@@ -800,6 +802,14 @@ def main(argv=None):
     if not coverage_report["gate"]["passed"]:
         raise RecommendationCoverageError(coverage_report)
 
+    # Verify redirect destinations before deleting any existing pages.
+    migrations = load_migrations(Path(DATA_DIR).parent)
+    registry = _read_json(Path(DATA_DIR) / "uri_registry.json") if migrations else {}
+    destination_pages = {"resource": {}, "software": {}}
+    for dataset, _, qid, slug in survivors:
+        destination_pages[dataset][qid] = slug
+    redirects = active_redirects(migrations, registry, destination_pages)
+
     # Step 5: The release gate passed; replace old generated pages.
     for d in ["resource", "software"]:
         dirpath = os.path.join(SITE_DIR, d)
@@ -829,7 +839,8 @@ def main(argv=None):
         page_slugs[dataset][qid] = slug
         generated += 1
 
-    print(f"Generated {generated} pages")
+    write_redirects(SITE_DIR, redirects)
+    print(f"Generated {generated} pages and {len(redirects)} redirects")
 
     # Step 7: Generate sitemap
     sitemap = generate_sitemap(pages)

--- a/scripts/uri_migrations.py
+++ b/scripts/uri_migrations.py
@@ -1,0 +1,83 @@
+"""Reviewed canonical URL migrations with permanent reservations for old slugs."""
+import html
+import json
+import re
+from pathlib import Path
+
+BASE_URL = "https://openknowledgegraphs.com"
+
+
+def load_migrations(root):
+    path = Path(root) / "validation/uri-migrations.json"
+    if not path.exists():
+        return []
+    rows = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(rows, list):
+        raise ValueError("URI migrations must be a list")
+    identities, sources, targets = set(), set(), set()
+    for row in rows:
+        if (not isinstance(row, dict) or row.get("dataset") not in {"resource", "software"}
+                or not re.fullmatch(r"Q[1-9][0-9]*", row.get("qid", ""))
+                or not all(re.fullmatch(r"[a-z0-9]+(?:-[a-z0-9]+)*", row.get(k, ""))
+                           for k in ("from", "to"))
+                or row["from"] == row["to"]):
+            raise ValueError("Invalid URI migration")
+        identity = (row["dataset"], row["qid"])
+        source = (row["dataset"], row["from"])
+        target = (row["dataset"], row["to"])
+        if identity in identities or source in sources or target in targets:
+            raise ValueError("Duplicate URI migration")
+        identities.add(identity)
+        sources.add(source)
+        targets.add(target)
+    if sources & targets:
+        raise ValueError("Chained or cyclic URI migrations are not supported")
+    return rows
+
+
+def permits(rows, dataset, qid, old, new):
+    return any(r["dataset"] == dataset and r["qid"] == qid
+               and r["from"] == old and r["to"] == new for r in rows)
+
+
+def apply_migrations(registry, rows):
+    for row in rows:
+        entries = registry.setdefault(row["dataset"], {})
+        for qid, slug in entries.items():
+            if qid != row["qid"] and slug in {row["from"], row["to"]}:
+                raise ValueError("URI migration conflicts with another identity")
+        current = entries.get(row["qid"])
+        if current is not None and current not in {row["from"], row["to"]}:
+            raise ValueError("URI migration does not match the reserved identity")
+        entries[row["qid"]] = row["to"]
+    return registry
+
+
+def redirect_document(target):
+    url = html.escape(target, quote=True)
+    return (f'<!doctype html><html lang="en"><head><meta charset="utf-8">'
+            f'<title>Resource moved</title><meta name="robots" content="noindex">'
+            f'<link rel="canonical" href="{url}">'
+            f'<meta http-equiv="refresh" content="0; url={url}"></head>'
+            f'<body><p>This resource has moved. <a href="{url}">Continue to its page</a>.</p>'
+            f'</body></html>\n')
+
+
+def active_redirects(rows, registry, page_qids):
+    active = []
+    for row in rows:
+        # A migration is pending until a normal catalog fetch changes the registry.
+        if registry.get(row["dataset"], {}).get(row["qid"]) != row["to"]:
+            continue
+        if page_qids.get(row["dataset"], {}).get(row["qid"]) != row["to"]:
+            raise ValueError("Migrated resource must have a verified destination page")
+        active.append(row)
+    return active
+
+
+def write_redirects(site, rows):
+    for row in rows:
+        page = Path(site) / row["dataset"] / row["from"] / "index.html"
+        page.parent.mkdir(parents=True, exist_ok=True)
+        page.write_text(redirect_document(
+            f'{BASE_URL}/{row["dataset"]}/{row["to"]}/'), encoding="utf-8")

--- a/scripts/validate_catalog.py
+++ b/scripts/validate_catalog.py
@@ -24,6 +24,7 @@ from rdflib.namespace import DCTERMS, RDF, RDFS, SKOS
 
 import fetch_data
 import semantic_config
+from uri_migrations import load_migrations, permits, active_redirects, redirect_document
 
 
 ROOT_DIR = Path(__file__).resolve().parent.parent
@@ -451,6 +452,7 @@ def validate_registry(
     baseline: dict[str, dict[str, str]] | None,
     payloads: dict[str, dict[str, Any]],
     report: ValidationReport,
+    migrations=(),
 ) -> None:
     for dataset, spec in DATASET_SPECS.items():
         registry_key = str(spec["registry"])
@@ -493,7 +495,7 @@ def validate_registry(
                     "registry-reservation",
                     f"Reserved {registry_key} identity {qid} was removed from uri_registry.json.",
                 )
-            elif new_slug != old_slug:
+            elif new_slug != old_slug and not permits(migrations, registry_key, qid, old_slug, new_slug):
                 report.error(
                     "uri-stability",
                     f"Reserved {registry_key} identity {qid} changed slug from {old_slug!r} to {new_slug!r}.",
@@ -519,6 +521,7 @@ def validate_regressions(
     payloads: dict[str, dict[str, Any]],
     baseline: BaselineSnapshot | None,
     report: ValidationReport,
+    migrations=(),
 ) -> None:
     if baseline is None:
         report.warning("baseline", "No committed baseline was available; regression checks were skipped.")
@@ -559,7 +562,11 @@ def validate_regressions(
         for qid in sorted(baseline_ids & current_ids):
             old_uri = baseline_index[qid].get("canonicalUrl")
             new_uri = current_index[qid].get("canonicalUrl")
-            if old_uri != new_uri:
+            if old_uri != new_uri and not permits(
+                migrations, str(spec["registry"]), qid,
+                str(old_uri).rstrip("/").rsplit("/", 1)[-1],
+                str(new_uri).rstrip("/").rsplit("/", 1)[-1],
+            ):
                 report.error(
                     "uri-stability",
                     f"Surviving {dataset} identity {qid} changed URI from {old_uri!r} to {new_uri!r}.",
@@ -753,6 +760,7 @@ def validate_page_contracts(
     payloads: dict[str, dict[str, Any]],
     baseline: BaselineSnapshot | None,
     report: ValidationReport,
+    migrations=(),
 ) -> None:
     try:
         page_qids = read_json(root / "data/page_qids.json")
@@ -793,7 +801,9 @@ def validate_page_contracts(
             if path.is_file()
         }
         mapped_slugs = set(mapping.values())
-        for slug in sorted(actual_slugs - mapped_slugs):
+        redirect_slugs = {r["from"] for r in migrations if r["dataset"] == dataset
+                          and mapping.get(r["qid"]) == r["to"]}
+        for slug in sorted(actual_slugs - mapped_slugs - redirect_slugs):
             report.error("page-contract", f"Unregistered generated page: site/{dataset}/{slug}/")
 
         if baseline is not None:
@@ -979,16 +989,27 @@ def validate_catalog(
     validate_public_iris(graphs.values(), payloads, report)
     _, _, mappings = validate_vocabularies_and_curation(root, graphs, payloads, report)
     validate_json_contract_and_projection(graphs, payloads, mappings, report)
+    migrations = load_migrations(root)
     validate_registry(
         registry,
         baseline.registry if baseline is not None else None,
         payloads,
         report,
+        migrations,
     )
-    validate_regressions(payloads, baseline, report)
+    validate_regressions(payloads, baseline, report, migrations)
     validate_mapping_coverage(root, mappings, report)
     validate_known_records(root, payloads, report)
-    validate_page_contracts(root, payloads, baseline, report)
+    validate_page_contracts(root, payloads, baseline, report, migrations)
+    try:
+        pages = read_json(root / "data/page_qids.json")
+        for row in active_redirects(migrations, registry, pages):
+            target = f'{BASE_URL}/{row["dataset"]}/{row["to"]}/'
+            path = root / "site" / row["dataset"] / row["from"] / "index.html"
+            if not path.is_file() or path.read_text() != redirect_document(target):
+                report.error("uri-redirect", f"Missing or invalid redirect for {row['qid']}")
+    except (ValueError, OSError) as exc:
+        report.error("uri-redirect", str(exc))
     return report
 
 

--- a/tests/test_page_membership.py
+++ b/tests/test_page_membership.py
@@ -104,6 +104,26 @@ class PageMembershipBaselineTests(unittest.TestCase):
             (self.candidate / "data/page_qids.json").read_text(encoding="utf-8")
         )
 
+    def test_reviewed_uri_migration_generates_only_one_canonical_page(self):
+        resource = item("Q123", "new-name", "https://example.test/resource")
+        self.write_candidate([resource])
+        row = {"dataset": "resource", "qid": "Q123", "from": "old-name", "to": "new-name"}
+        write_json(self.candidate / "validation/uri-migrations.json", [row])
+        write_json(self.candidate / "data/uri_registry.json",
+                   {"resource": {"Q123": "new-name"}, "software": {}})
+        self.run_generator(good_urls=[resource["homepage"]])
+        self.assertEqual(self.page_registry()["resource"], {"Q123": "new-name"})
+        old = (self.candidate / "site/resource/old-name/index.html").read_text()
+        self.assertIn('http-equiv="refresh"', old)
+        sitemap = (self.candidate / "site/sitemap.xml").read_text()
+        self.assertIn("/resource/new-name/", sitemap)
+        self.assertNotIn("/resource/old-name/", sitemap)
+        report = validate_catalog.ValidationReport()
+        validate_catalog.validate_page_contracts(
+            self.candidate, {"resource": {"items": [resource]}, "software": {"items": []}},
+            None, report, [row])
+        self.assertFalse(report.errors, report.errors)
+
     def test_unchanged_verified_page_survives_failed_checks_for_new_candidates(self):
         stable = item("Q1", "stable", "https://example.test/stable")
         new = item("Q2", "new", "https://example.test/new")

--- a/tests/test_uri_migrations.py
+++ b/tests/test_uri_migrations.py
@@ -1,0 +1,57 @@
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'scripts'))
+import uri_migrations as migrations
+import validate_catalog
+
+ROW = {'dataset':'resource','qid':'Q123','from':'old-name','to':'new-name'}
+
+
+class UriMigrationTests(unittest.TestCase):
+    def test_migration_is_idempotent_and_rejects_collisions(self):
+        registry={'resource':{'Q123':'old-name'}}
+        migrations.apply_migrations(registry,[ROW])
+        migrations.apply_migrations(registry,[ROW])
+        self.assertEqual(registry['resource']['Q123'],'new-name')
+        for slug in ['old-name','new-name']:
+            with self.assertRaises(ValueError):
+                migrations.apply_migrations({'resource':{'Q123':'old-name','Q456':slug}},[ROW])
+        with self.assertRaises(ValueError):
+            migrations.apply_migrations({'resource':{'Q123':'unexpected'}},[ROW])
+
+    def test_unapproved_changes_still_fail_registry_validation(self):
+        baseline={'resource':{'Q123':'old-name'},'software':{}}
+        current={'resource':{'Q123':'new-name'},'software':{}}
+        payloads={'resource':{'items':[{'wikidataId':'https://www.wikidata.org/wiki/Q123','canonicalUrl':'https://openknowledgegraphs.com/resource/new-name/'}]},'software':{'items':[]}}
+        report=validate_catalog.ValidationReport()
+        validate_catalog.validate_registry(current,baseline,payloads,report)
+        self.assertTrue(any(e.code=='uri-stability' for e in report.errors))
+        report=validate_catalog.ValidationReport()
+        validate_catalog.validate_registry(current,baseline,payloads,report,[ROW])
+        self.assertFalse(report.errors)
+        self.assertFalse(migrations.permits([ROW],'resource','Q456','old-name','new-name'))
+        self.assertFalse(migrations.permits([ROW],'resource','Q123','new-name','old-name'))
+
+    def test_redirect_requires_verified_destination_and_is_not_a_second_item(self):
+        registry={'resource':{'Q123':'new-name'}}
+        with self.assertRaises(ValueError):migrations.active_redirects([ROW],registry,{'resource':{}})
+        pages={'resource':{'Q123':'new-name'}}
+        rows=migrations.active_redirects([ROW],registry,pages)
+        with tempfile.TemporaryDirectory() as directory:
+            migrations.write_redirects(directory,rows)
+            html=(Path(directory)/'resource/old-name/index.html').read_text()
+            self.assertIn('http-equiv="refresh"',html)
+            self.assertIn('rel="canonical" href="https://openknowledgegraphs.com/resource/new-name/"',html)
+            self.assertIn('content="noindex"',html)
+        self.assertEqual(pages,{'resource':{'Q123':'new-name'}})
+        self.assertEqual(migrations.active_redirects([ROW],{'resource':{'Q123':'old-name'}},{}),[])
+
+    def test_invalid_paths_and_chains_are_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root=Path(directory);(root/'validation').mkdir()
+            for rows in [[{**ROW,'from':'../escape'}], [ROW,{**ROW,'qid':'Q456','from':'new-name','to':'next'}], [ROW,ROW]]:
+                (root/'validation/uri-migrations.json').write_text(json.dumps(rows))
+                with self.assertRaises(ValueError):migrations.load_migrations(root)

--- a/validation/uri-migrations.json
+++ b/validation/uri-migrations.json
@@ -1,0 +1,9 @@
+[
+  {
+    "dataset": "resource",
+    "qid": "Q141411204",
+    "from": "universal-evidence-states-and-indicators-thesaurus",
+    "to": "universal-evidence-conditions-and-outcomes-thesaurus",
+    "reason": "Use the approved public name; states is ambiguous with geographic states."
+  }
+]


### PR DESCRIPTION
The Universal Evidence thesaurus now uses its approved public name, Conditions and Outcomes. Its existing OKG slug was permanently reserved under States and Indicators, so refreshing its Wikidata label alone would leave the unwanted URL in place.

Add an explicit, QID-scoped migration to `universal-evidence-conditions-and-outcomes-thesaurus`, applied during the next catalog fetch. Generate an HTML redirect with a canonical link at the old URL, reserve the old slug, and require a verified destination. The sitemap and page membership retain only the canonical resource. Unapproved URI changes continue to fail validation.

Validation: all 200 root tests pass; current catalog validation passes with zero warnings/errors. Tests cover migration collisions, direction and identity restrictions, redirect destination requirements, and canonical page/sitemap generation. Generated catalog files will be updated by publication after merge.
