### PR TITLE
Fix Emply vacancy JSON decoding and validate catalog redirects

### DIFF
--- a/jobs/scripts/first_party_sources.py
+++ b/jobs/scripts/first_party_sources.py
@@ -2698,13 +2698,54 @@ class _EmplyDetailParser(_ClassContainerParser):
         return _strip_html(" ".join(self.title_parts))
 
 
+def _decode_emply_string(value: str) -> str:
+    """Decode Emply's single-quoted JavaScript string without executing code.
+
+    Convert the outer string to JSON string syntax, preserving its escapes.
+    The resulting text is still JSON and must be parsed separately.
+    """
+    parts = []
+    index = 0
+    while index < len(value):
+        char = value[index]
+        index += 1
+        if char == "\\":
+            if index == len(value):
+                raise ValueError("Unterminated JavaScript escape")
+            escaped = value[index]
+            index += 1
+            if escaped == "'":
+                parts.append("'")
+            elif escaped == "v":
+                parts.append(r"\u000b")
+            elif escaped == "x":
+                digits = value[index:index + 2]
+                if not re.fullmatch(r"[0-9a-fA-F]{2}", digits):
+                    raise ValueError("Invalid JavaScript hex escape")
+                parts.append(r"\u00" + digits)
+                index += 2
+            elif escaped in "\r\n":
+                if escaped == "\r" and value[index:index + 1] == "\n":
+                    index += 1
+            else:
+                # JSON validates backslashes, quotes, controls and Unicode escapes.
+                parts.append("\\" + escaped)
+        elif char == '"':
+            parts.append(r'\"')
+        elif char == "'":
+            raise ValueError("Unescaped JavaScript string delimiter")
+        else:
+            parts.append(char)
+    return json.loads('"' + "".join(parts) + '"')
+
+
 def _emply_listing(payload: str, source: FirstPartySource) -> list[dict]:
     matches = re.findall(r"proceedBatch\(\{ vacancies : JSON\.parse\('(\[.*?\])'\), count : (\d+)\}\);", payload, re.DOTALL)
     if len(matches) != 1:
         raise FirstPartySourceError("Emply listing lacks one embedded bounded vacancy batch")
     try:
-        rows = json.loads(matches[0][0].replace(r'\"', '"').replace(r"\'", "'"))
-    except json.JSONDecodeError as exc:
+        rows = json.loads(_decode_emply_string(matches[0][0]))
+    except ValueError as exc:
         raise FirstPartySourceError("Emply embedded vacancy batch is malformed") from exc
     if not isinstance(rows, list) or int(matches[0][1]) != len(rows):
         raise FirstPartySourceError("Emply embedded vacancy batch is partial")

--- a/jobs/tests/test_emply_decoding.py
+++ b/jobs/tests/test_emply_decoding.py
@@ -1,0 +1,48 @@
+"""Emply listings contain JSON inside a JavaScript string literal."""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'scripts'))
+import first_party_sources as fps
+
+
+@pytest.fixture(scope='module')
+def source():
+    return fps.load_first_party_sources()['first-party-danish-bibliographic-centre']
+
+
+def listing(rows, count=None):
+    # Encode JSON as a JS string, as Emply's JSON.parse('...') embedding does.
+    encoded = json.dumps(json.dumps(rows, ensure_ascii=False), ensure_ascii=False)[1:-1]
+    encoded = encoded.replace("'", r"\'")
+    return "proceedBatch({ vacancies : JSON.parse('" + encoded + "'), count : " + str(len(rows) if count is None else count) + "});"
+
+
+def test_nested_html_quotes_unicode_backslashes_and_apostrophes(source):
+    rows = [{'shortId': 'example', 'title': 'Bibliotekar – København 📚',
+             'description': '<a href="https://example.org/">Danish library</a>\nReader\'s path C:\\new\\texts; literal \\u0026'}]
+    assert fps._emply_listing(listing(rows), source) == rows
+
+
+def test_realistic_emply_html_unicode_escaping(source):
+    embedded = r'''[{\"shortId\":\"example\",\"description\":\"\\u003ca href=\\\"https://example.org/\\\"\\u003eLæs mere\\u003c/a\\u003e\"}]'''
+    payload = "proceedBatch({ vacancies : JSON.parse('" + embedded + "'), count : 1});"
+    assert fps._emply_listing(payload, source)[0]['description'] == '<a href="https://example.org/">Læs mere</a>'
+
+
+@pytest.mark.parametrize('raw', [r'[{\"title\":\"bad\q\"}]', r'[{\"title\":\"bad\xZZ\"}]', r'[{invalid}]'])
+def test_malformed_embedded_json_is_rejected(source, raw):
+    with pytest.raises(fps.FirstPartySourceError, match='malformed'):
+        fps._emply_listing("proceedBatch({ vacancies : JSON.parse('" + raw + "'), count : 1});", source)
+
+
+def test_empty_talent_pool_and_partial_batch_rules(source):
+    assert fps._emply_listing(listing([]), source) == []
+    assert fps._emply_listing(listing([{'talentPool': True}]), source) == []
+    with pytest.raises(fps.FirstPartySourceError, match='partial'):
+        fps._emply_listing(listing([{'shortId': 'example'}], count=2), source)
+    with pytest.raises(fps.FirstPartySourceError, match='one embedded'):
+        fps._emply_listing(listing([]) + listing([]), source)

--- a/tests/test_semantic_metadata.py
+++ b/tests/test_semantic_metadata.py
@@ -13,6 +13,7 @@ sys.path.insert(0, str(SCRIPTS_DIR))
 
 import fetch_data  # noqa: E402
 import generate_pages  # noqa: E402
+import uri_migrations  # noqa: E402
 
 
 PUBLIC_DOMAIN_MARK = "https://creativecommons.org/publicdomain/mark/1.0/"
@@ -309,6 +310,17 @@ class OntologyTests(unittest.TestCase):
 
 class CommittedPageTests(unittest.TestCase):
     @staticmethod
+    def committed_redirects():
+        registry = json.loads((ROOT / "data/uri_registry.json").read_text(encoding="utf-8"))
+        pages = json.loads((ROOT / "data/page_qids.json").read_text(encoding="utf-8"))
+        rows = uri_migrations.active_redirects(uri_migrations.load_migrations(ROOT), registry, pages)
+        return {
+            f"site/{row['dataset']}/{row['from']}/index.html": uri_migrations.redirect_document(
+                f"{generate_pages.BASE_URL}/{row['dataset']}/{row['to']}/")
+            for row in rows
+        }
+
+    @staticmethod
     def committed_pages():
         return sorted(
             [
@@ -336,7 +348,7 @@ class CommittedPageTests(unittest.TestCase):
             for slug in entries.values()
         }
         committed_paths = {str(page.relative_to(ROOT)) for page in self.committed_pages()}
-        self.assertEqual(committed_paths, registered_paths)
+        self.assertEqual(committed_paths, registered_paths | set(self.committed_redirects()))
 
     def test_committed_pages_match_deterministic_catalog_render(self):
         items_by_url = {}
@@ -351,12 +363,19 @@ class CommittedPageTests(unittest.TestCase):
             )
 
         pages = self.committed_pages()
+        redirects = self.committed_redirects()
         survivor_urls = {
             f"{generate_pages.BASE_URL}/{page.parent.parent.name}/{page.parent.name}/"
             for page in pages
+            if str(page.relative_to(ROOT)) not in redirects
         }
         mismatches = []
         for page in pages:
+            relative_path = str(page.relative_to(ROOT))
+            if relative_path in redirects:
+                if page.read_text(encoding="utf-8") != redirects[relative_path]:
+                    mismatches.append(relative_path)
+                continue
             dataset = page.parent.parent.name
             slug = page.parent.name
             canonical_url = f"{generate_pages.BASE_URL}/{dataset}/{slug}/"


### PR DESCRIPTION
The Danish Bibliographic Centre refresh failed when Emply embedded a vacancy description containing quoted HTML links. The adapter partially unescaped the JavaScript string and passed invalid JSON to the parser, retaining the prior snapshot and making the jobs workflow red.

Decode the outer single-quoted JavaScript string without executing code, then parse its JSON separately. Preserve nested quotes, Unicode and backslashes while keeping malformed/partial batches rejected and the existing last-good fallback intact.

Validation: 114 focused jobs tests passed, including regression cases for nested HTML quotes and malformed feeds. The previously failing captured page now parses. A bounded live pilot completed discovery, detail parsing and classification: one UX Designer vacancy, zero KG-qualified jobs; no local pilot output published.

Also update the committed-page tests for the existing approved URI redirects now present in main: verify their exact redirect HTML and keep them outside the canonical resource set. This resolves two baseline test failures introduced when the earlier URI migration was published; undeclared extra pages remain rejected.

All 200 root regression tests pass after that correction.
